### PR TITLE
Added a yaml construct method for Trainer

### DIFF
--- a/azure/install_dependencies.sh
+++ b/azure/install_dependencies.sh
@@ -2,5 +2,5 @@
 
 python -m pip install --upgrade pip
 pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-pip install tqdm ase tensorboardX
+pip install tqdm ase tensorboardX pyyaml
 pip install pytorch-ignite --no-deps

--- a/azure/runnable_submodules.yml
+++ b/azure/runnable_submodules.yml
@@ -18,5 +18,8 @@ steps:
 - script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.ipt  dataset/ani_gdb_s01.h5 dataset/ani_gdb_s01.h5'
   displayName: NeuroChem Trainer
 
+- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.yaml  dataset/ani_gdb_s01.h5 dataset/ani_gdb_s01.h5'
+  displayName: NeuroChem Trainer YAML config
+
 - script: 'python -m torchani.data.cache_aev tmp dataset/ani_gdb_s01.h5 256'
   displayName: Cache AEV

--- a/tests/test_data/inputtrain.yaml
+++ b/tests/test_data/inputtrain.yaml
@@ -1,0 +1,106 @@
+# InputFile for Force Prediction Network
+sflparamsfile: 'rHCNO-5.2R_16-3.5A_a4-8.params'
+ntwkStoreDir: 'networks/'
+atomEnergyFile: 'sae_linfit.dat'
+nmax: 0 # Maximum number of iterations (0 = inf)
+tolr: 1 # Tolerance - early stopping
+emult: 0.1 # Multiplier by eta after tol switch
+eta: 0.001 # Eta -- Learning rate
+tcrit: 1.0E-5 # Eta termination criterion
+tmax: 0 # Maximum time (0 = inf)
+tbtchsz: 2560
+vbtchsz: 2560
+gpuid: 0
+ntwshr: 0
+nkde: 2
+energy: 1
+force: 0
+fmult: 0.0
+pbc: 0
+cmult: 0.001
+runtype: 'ANNP_CREATE_HDNN_AND_TRAIN' # Create and train a HDN network
+
+network_setup:
+  inputsize: 384
+  atom_net:
+    H:
+      - nodes: 160
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.0001
+      - nodes: 128
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.00001
+      - nodes: 96
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.000001
+      - nodes: 1
+        activation: 6
+        type: 0
+    C:
+      - nodes: 144
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.0001
+      - nodes: 112
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.00001
+      - nodes: 96
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.000001
+      - nodes: 1
+        activation: 6
+        type: 0
+    N:
+      - nodes: 128
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.0001
+      - nodes: 112
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.00001
+      - nodes: 96
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.000001
+      - nodes: 1
+        activation: 6
+        type: 0
+    O:
+      - nodes: 128
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.0001
+      - nodes: 112
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.00001
+      - nodes: 96
+        activation: 9
+        type: 0
+        # l2norm: 1
+        # l2valu: 0.000001
+      - nodes: 1
+        activation: 6
+        type: 0
+
+adptlrn: 'OFF' # Adaptive learning (OFF,RMSPROP)
+decrate: 0.9 # Decay rate of RMSPROP
+moment: 'ADAM' #  Turn on momentum or nesterov momentum (OFF,CNSTTEMP,TMANNEAL,REGULAR,NESTEROV)
+mu: 0.99 # Mu factor for momentum

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -443,7 +443,7 @@ class Trainer:
 
     def _construct_from_yaml(self):
         import yaml
-        config = yaml.load(open(self.filename, 'r'))
+        config = yaml.safe_load(open(self.filename, 'r'))
         dir_ = os.path.dirname(os.path.abspath(self.filename))
 
         # delete ignored params

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -337,9 +337,12 @@ class Trainer:
             self.training_eval_every = 20
         else:
             self.tensorboard = None
-        with open(filename, 'r') as f:
-            network_setup, params = self._parse(f.read())
-            self._construct(network_setup, params)
+        if filename.endswith('.yaml') or filename.endswith('.yml'):
+            self._construct_from_yaml()
+        else:
+            with open(filename, 'r') as f:
+                network_setup, params = self._parse(f.read())
+                self._construct(network_setup, params)
 
     def _parse(self, txt):
         parser = lark.Lark(r'''
@@ -437,6 +440,128 @@ class Trainer:
                 return v[0].value
 
         return TreeExec().transform(tree)
+
+    def _construct_from_yaml(self):
+        import yaml
+        config = yaml.load(open(self.filename, 'r'))
+        dir_ = os.path.dirname(os.path.abspath(self.filename))
+
+        # delete ignored params
+        def del_if_exists(key):
+            if key in config:
+                del config[key]
+
+        def assert_param(key, value):
+            if key in config and config[key] != value:
+                raise NotImplementedError(key + ' not supported yet')
+            del config[key]
+
+        del_if_exists('gpuid')
+        del_if_exists('nkde')
+        del_if_exists('fmult')
+        del_if_exists('cmult')
+        del_if_exists('decrate')
+        del_if_exists('mu')
+        assert_param('pbc', 0)
+        assert_param('force', 0)
+        assert_param('energy', 1)
+        assert_param('moment', 'ADAM')
+        assert_param('runtype', 'ANNP_CREATE_HDNN_AND_TRAIN')
+        assert_param('adptlrn', 'OFF')
+        assert_param('tmax', 0)
+        assert_param('nmax', 0)
+        assert_param('ntwshr', 0)
+
+        # load parameters
+        self.const_file = os.path.join(dir_, config['sflparamsfile'])
+        self.consts = Constants(self.const_file)
+        self.aev_computer = AEVComputer(**self.consts)
+        del config['sflparamsfile']
+        self.sae_file = os.path.join(dir_, config['atomEnergyFile'])
+        self.shift_energy = load_sae(self.sae_file)
+        del config['atomEnergyFile']
+        network_dir = os.path.join(dir_, config['ntwkStoreDir'])
+        if not os.path.exists(network_dir):
+            os.makedirs(network_dir)
+        self.model_checkpoint = os.path.join(network_dir, self.checkpoint_name)
+        del config['ntwkStoreDir']
+        self.max_nonimprove = config['tolr']
+        del config['tolr']
+        self.init_lr = config['eta']
+        del config['eta']
+        self.lr_decay = config['emult']
+        del config['emult']
+        self.min_lr = config['tcrit']
+        del config['tcrit']
+        self.training_batch_size = config['tbtchsz']
+        del config['tbtchsz']
+        self.validation_batch_size = config['vbtchsz']
+        del config['vbtchsz']
+
+        # construct networks
+        input_size = config['network_setup']['inputsize']
+        atom_nets = config['network_setup']['atom_net']
+        if input_size != self.aev_computer.aev_length():
+            raise ValueError('AEV size and input size does not match')
+        l2reg = []
+        atomic_nets = {}
+        for atom_type in atom_nets:
+            layers = atom_nets[atom_type]['layers']
+            modules = []
+            i = input_size
+            for layer in layers:
+                o = layer['nodes']
+                del layer['nodes']
+                if layer['type'] != 0:
+                    raise ValueError('Unsupported layer type')
+                del layer['type']
+                module = torch.nn.Linear(i, o)
+                modules.append(module)
+                activation = _get_activation(layer['activation'])
+                if activation is not None:
+                    modules.append(activation)
+                del layer['activation']
+                if 'l2norm' in layer:
+                    if layer['l2norm'] == 1:
+                        # NB: The "L2" implemented in NeuroChem is actually not
+                        # L2 but weight decay. The difference of these two is:
+                        # https://arxiv.org/pdf/1711.05101.pdf
+                        # There is a pull request on github/pytorch
+                        # implementing AdamW, etc.:
+                        # https://github.com/pytorch/pytorch/pull/4429
+                        # There is no plan to support the "L2" settings in
+                        # input file before AdamW get merged into pytorch.
+                        raise NotImplementedError('L2 not supported yet')
+                    del layer['l2norm']
+                    del layer['l2valu']
+                if layer:
+                    raise ValueError('unrecognized parameter in layer setup')
+                i = o
+            atomic_nets[atom_type] = torch.nn.Sequential(*modules)
+
+        del config['network_setup']
+        self.model = ANIModel([atomic_nets[s] for s in self.consts.species])
+        if self.aev_caching:
+            self.nnp = self.model
+        else:
+            self.nnp = torch.nn.Sequential(self.aev_computer, self.model)
+        self.container = Container({'energies': self.nnp}).to(self.device)
+
+        # losses
+        def l2():
+            return sum([c * (m.weight ** 2).sum() for c, m in l2reg])
+        self.mse_loss = TransformedLoss(MSELoss('energies'),
+                                        lambda x: x + l2())
+        self.exp_loss = TransformedLoss(
+            MSELoss('energies'),
+            lambda x: 0.5 * (torch.exp(2 * x) - 1) + l2())
+
+        if config:
+            raise ValueError('unrecognized parameter')
+
+        self.global_epoch = 0
+        self.global_iteration = 0
+        self.best_validation_rmse = math.inf
 
     def _construct(self, network_setup, params):
         dir_ = os.path.dirname(os.path.abspath(self.filename))


### PR DESCRIPTION
I don't really know if you are interested in this. If not feel free to just close the PR. 
I just like config files in `yaml` as I find them more readable and they save you from defining a grammar or using lark.
Only thing it doesn't do is type check but I see that the lark definition is also quite flexible on the types.
I kept the lark parser in there just in case although this causes some obvious code duplication.

This is what the `yaml` file looks like although it's structure can be changed very easily.
https://gist.github.com/stefdoerr/47abc07538246a1b5026955453a83cdf

In the end I guess it's a personal taste issue so if you don't care for it or you didn't use yaml on purpose feel free to close this as I said :)