### PR TITLE
Reformat the BuiltinModels and Builtins API to make them simpler and clearer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@ benchmark_xyz
 datacache
 dist
 *.pckl
-
+# No vim swap files
+*.swp
+*.swo

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -29,19 +29,14 @@ class TestAEV(unittest.TestCase):
     def transform(self, x):
         return x
 
-    def assertAEVEqual(self,
-                       expected_radial,
-                       expected_angular,
-                       aev,
-                       tolerance=tolerance):
+    def assertAEVEqual(
+            self, expected_radial, expected_angular, aev, tolerance=tolerance):
         radial = aev[..., :self.radial_length]
         angular = aev[..., self.radial_length:]
         radial_diff = expected_radial - radial
         if self.debug:
             aid = 1
-            print(torch.stack([
-                expected_radial[0, aid, :], radial[0, aid, :],
-                radial_diff.abs()[0, aid, :]], dim=1))
+            print(torch.stack([expected_radial[0, aid, :], radial[0, aid, :], radial_diff.abs()[0, aid, :]], dim=1))
         radial_max_error = torch.max(torch.abs(radial_diff)).item()
         angular_diff = expected_angular - angular
         angular_max_error = torch.max(torch.abs(angular_diff)).item()
@@ -72,8 +67,7 @@ class TestAEV(unittest.TestCase):
             with open(datafile, 'rb') as f:
                 coordinates, species, expected_radial, expected_angular, _, _, cell, pbc \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
-                    0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
                 species = torch.from_numpy(species).unsqueeze(0)
                 expected_radial = torch.from_numpy(
                     expected_radial).float().unsqueeze(0)
@@ -88,8 +82,8 @@ class TestAEV(unittest.TestCase):
                 expected_radial = self.transform(expected_radial)
                 expected_angular = self.transform(expected_angular)
                 _, aev = self.aev_computer((species, coordinates, cell, pbc))
-                self.assertAEVEqual(expected_radial, expected_angular, aev,
-                                    5e-5)
+                self.assertAEVEqual(
+                    expected_radial, expected_angular, aev, 5e-5)
 
     def testTripeptideMD(self):
         tol = 5e-6
@@ -99,8 +93,7 @@ class TestAEV(unittest.TestCase):
             with open(datafile, 'rb') as f:
                 coordinates, species, expected_radial, expected_angular, _, _, _, _ \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
-                    0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
                 species = torch.from_numpy(species).unsqueeze(0)
                 expected_radial = torch.from_numpy(
                     expected_radial).float().unsqueeze(0)
@@ -111,8 +104,7 @@ class TestAEV(unittest.TestCase):
                 expected_radial = self.transform(expected_radial)
                 expected_angular = self.transform(expected_angular)
                 _, aev = self.aev_computer((species, coordinates))
-                self.assertAEVEqual(expected_radial, expected_angular, aev,
-                                    tol)
+                self.assertAEVEqual(expected_radial, expected_angular, aev, tol)
 
     def testPadding(self):
         species_coordinates = []
@@ -129,10 +121,8 @@ class TestAEV(unittest.TestCase):
                 species = self.transform(species)
                 radial = self.transform(radial)
                 angular = self.transform(angular)
-                species_coordinates.append({
-                    'species': species,
-                    'coordinates': coordinates
-                })
+                species_coordinates.append(
+                    {'species': species, 'coordinates': coordinates})
                 radial_angular.append((radial, angular))
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
@@ -202,10 +192,11 @@ class TestPBCSeeEachOther(unittest.TestCase):
         self.aev_computer = self.ani1x.aev_computer.to(torch.double)
 
     def testTranslationalInvariancePBC(self):
-        coordinates = torch.tensor(
-            [[[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 1, 1]]],
-            dtype=torch.double,
-            requires_grad=True)
+        coordinates = torch.tensor([[[0, 0, 0],
+                                     [1, 0, 0],
+                                     [0, 1, 0],
+                                     [0, 0, 1],
+                                     [0, 1, 1]]], dtype=torch.double, requires_grad=True)
         cell = torch.eye(3, dtype=torch.double) * 2
         species = torch.tensor([[1, 0, 0, 0, 0]], dtype=torch.long)
         pbc = torch.ones(3, dtype=torch.uint8)
@@ -232,12 +223,11 @@ class TestPBCSeeEachOther(unittest.TestCase):
             torch.tensor([9.9, 9.9, 0.0]),
             torch.tensor([0.0, 9.9, 9.9]),
             torch.tensor([9.9, 0.0, 9.9]),
-            torch.tensor([9.9, 9.9, 9.9]),
-        ]
+            torch.tensor([9.9, 9.9, 9.9])]
 
         for xyz2 in xyz2s:
-            coordinates = torch.stack([xyz1,
-                                       xyz2]).to(torch.double).unsqueeze(0)
+            coordinates = torch.stack([xyz1, xyz2]).to(
+                torch.double).unsqueeze(0)
             atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
                 species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
@@ -309,10 +299,11 @@ class TestAEVOnBoundary(unittest.TestCase):
         self.cell = torch.tensor(ase.geometry.complete_cell(cell),
                                  dtype=torch.double)
         self.inv_cell = torch.inverse(self.cell)
-        self.coordinates = torch.tensor(
-            [[[0.0, 0.0, 0.0], [1.0, -0.1, -0.1], [-0.1, 1.0, -0.1],
-              [-0.1, -0.1, 1.0], [-1.0, -1.0, -1.0]]],
-            dtype=torch.double)
+        self.coordinates = torch.tensor([[[0.0, 0.0, 0.0],
+                                          [1.0, -0.1, -0.1],
+                                          [-0.1, 1.0, -0.1],
+                                          [-0.1, -0.1, 1.0],
+                                          [-1.0, -1.0, -1.0]]], dtype=torch.double)
         self.species = torch.tensor([[1, 0, 0, 0]])
         self.pbc = torch.ones(3, dtype=torch.uint8)
         self.v1, self.v2, self.v3 = self.cell

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -19,8 +19,8 @@ tolerance = 1e-5
 class TestAEV(unittest.TestCase):
 
     def setUp(self):
-        builtins = torchani.neurochem.Builtins()
-        self.aev_computer = builtins.aev_computer
+        ani1x = torchani.models.ANI1x()
+        self.aev_computer = ani1x.aev_computer
         self.radial_length = self.aev_computer.radial_length
         self.debug = False
 
@@ -179,8 +179,8 @@ class TestAEV(unittest.TestCase):
 class TestPBCSeeEachOther(unittest.TestCase):
 
     def setUp(self):
-        self.builtin = torchani.neurochem.Builtins()
-        self.aev_computer = self.builtin.aev_computer.to(torch.double)
+        self.ani1x = torchani.models.ANI1x()
+        self.aev_computer = self.ani1x.aev_computer.to(torch.double)
 
     def testTranslationalInvariancePBC(self):
         coordinates = torch.tensor(
@@ -293,8 +293,8 @@ class TestAEVOnBoundary(unittest.TestCase):
         self.pbc = torch.ones(3, dtype=torch.uint8)
         self.v1, self.v2, self.v3 = self.cell
         self.center_coordinates = self.coordinates + 0.5 * (self.v1 + self.v2 + self.v3)
-        builtin = torchani.neurochem.Builtins()
-        self.aev_computer = builtin.aev_computer.to(torch.double)
+        ani1x = torchani.models.ANI1x()
+        self.aev_computer = ani1x.aev_computer.to(torch.double)
         _, self.aev = self.aev_computer((self.species, self.center_coordinates, self.cell, self.pbc))
 
     def assertInCell(self, coordinates):
@@ -325,8 +325,8 @@ class TestAEVOnBoundary(unittest.TestCase):
 class TestAEVOnBenzenePBC(unittest.TestCase):
 
     def setUp(self):
-        builtins = torchani.neurochem.Builtins()
-        self.aev_computer = builtins.aev_computer
+        ani1x = torchani.models.ANI1x()
+        self.aev_computer = ani1x.aev_computer
         filename = os.path.join(path, '../tools/generate-unit-test-expect/others/Benzene.cif')
         benzene = ase.io.read(filename)
         self.cell = torch.tensor(benzene.get_cell(complete=True)).float()

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -17,7 +17,6 @@ tolerance = 1e-5
 
 
 class TestAEV(unittest.TestCase):
-
     def setUp(self):
         ani1x = torchani.models.ANI1x()
         self.aev_computer = ani1x.aev_computer
@@ -30,13 +29,19 @@ class TestAEV(unittest.TestCase):
     def transform(self, x):
         return x
 
-    def assertAEVEqual(self, expected_radial, expected_angular, aev, tolerance=tolerance):
+    def assertAEVEqual(self,
+                       expected_radial,
+                       expected_angular,
+                       aev,
+                       tolerance=tolerance):
         radial = aev[..., :self.radial_length]
         angular = aev[..., self.radial_length:]
         radial_diff = expected_radial - radial
         if self.debug:
             aid = 1
-            print(torch.stack([expected_radial[0, aid, :], radial[0, aid, :], radial_diff.abs()[0, aid, :]], dim=1))
+            print(torch.stack([
+                expected_radial[0, aid, :], radial[0, aid, :],
+                radial_diff.abs()[0, aid, :]], dim=1))
         radial_max_error = torch.max(torch.abs(radial_diff)).item()
         angular_diff = expected_angular - angular
         angular_max_error = torch.max(torch.abs(angular_diff)).item()
@@ -62,41 +67,52 @@ class TestAEV(unittest.TestCase):
 
     def testBenzeneMD(self):
         for i in range(10):
-            datafile = os.path.join(path, 'test_data/benzene-md/{}.dat'.format(i))
+            datafile = os.path.join(path,
+                                    'test_data/benzene-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, expected_radial, expected_angular, _, _, cell, pbc \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
+                    0)
                 species = torch.from_numpy(species).unsqueeze(0)
-                expected_radial = torch.from_numpy(expected_radial).float().unsqueeze(0)
-                expected_angular = torch.from_numpy(expected_angular).float().unsqueeze(0)
+                expected_radial = torch.from_numpy(
+                    expected_radial).float().unsqueeze(0)
+                expected_angular = torch.from_numpy(
+                    expected_angular).float().unsqueeze(0)
                 cell = torch.from_numpy(cell).float()
                 pbc = torch.from_numpy(pbc)
-                coordinates = torchani.utils.map2central(cell, coordinates, pbc)
+                coordinates = torchani.utils.map2central(
+                    cell, coordinates, pbc)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 expected_radial = self.transform(expected_radial)
                 expected_angular = self.transform(expected_angular)
                 _, aev = self.aev_computer((species, coordinates, cell, pbc))
-                self.assertAEVEqual(expected_radial, expected_angular, aev, 5e-5)
+                self.assertAEVEqual(expected_radial, expected_angular, aev,
+                                    5e-5)
 
     def testTripeptideMD(self):
         tol = 5e-6
         for i in range(100):
-            datafile = os.path.join(path, 'test_data/tripeptide-md/{}.dat'.format(i))
+            datafile = os.path.join(path,
+                                    'test_data/tripeptide-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, expected_radial, expected_angular, _, _, _, _ \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
+                    0)
                 species = torch.from_numpy(species).unsqueeze(0)
-                expected_radial = torch.from_numpy(expected_radial).float().unsqueeze(0)
-                expected_angular = torch.from_numpy(expected_angular).float().unsqueeze(0)
+                expected_radial = torch.from_numpy(
+                    expected_radial).float().unsqueeze(0)
+                expected_angular = torch.from_numpy(
+                    expected_angular).float().unsqueeze(0)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 expected_radial = self.transform(expected_radial)
                 expected_angular = self.transform(expected_angular)
                 _, aev = self.aev_computer((species, coordinates))
-                self.assertAEVEqual(expected_radial, expected_angular, aev, tol)
+                self.assertAEVEqual(expected_radial, expected_angular, aev,
+                                    tol)
 
     def testPadding(self):
         species_coordinates = []
@@ -113,11 +129,15 @@ class TestAEV(unittest.TestCase):
                 species = self.transform(species)
                 radial = self.transform(radial)
                 angular = self.transform(angular)
-                species_coordinates.append({'species': species, 'coordinates': coordinates})
+                species_coordinates.append({
+                    'species': species,
+                    'coordinates': coordinates
+                })
                 radial_angular.append((radial, angular))
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
-        _, aev = self.aev_computer((species_coordinates['species'], species_coordinates['coordinates']))
+        _, aev = self.aev_computer((species_coordinates['species'],
+                                    species_coordinates['coordinates']))
         start = 0
         for expected_radial, expected_angular in radial_angular:
             conformations = expected_radial.shape[0]
@@ -149,11 +169,13 @@ class TestAEV(unittest.TestCase):
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         # Create local copy of aev_computer to avoid interference with other
         # tests.
-        aev_computer = copy.deepcopy(self.aev_computer).to(device).to(torch.float64)
+        aev_computer = copy.deepcopy(self.aev_computer).to(device).to(
+            torch.float64)
         with open(datafile, 'rb') as f:
             data = pickle.load(f)
             for coordinates, species, _, _, _, _ in data:
-                coordinates = torch.from_numpy(coordinates).to(device).to(torch.float64)
+                coordinates = torch.from_numpy(coordinates).to(device).to(
+                    torch.float64)
                 coordinates.requires_grad_(True)
                 species = torch.from_numpy(species).to(device)
 
@@ -168,28 +190,22 @@ class TestAEV(unittest.TestCase):
                 def aev_forward_wrapper(coords):
                     # Return only the aev portion of the output.
                     return aev_computer((species, coords))[1]
+
                 # Sanity Check: Forward wrapper returns aev without error.
                 aev_forward_wrapper(coordinates)
-                torch.autograd.gradcheck(
-                    aev_forward_wrapper,
-                    coordinates
-                )
+                torch.autograd.gradcheck(aev_forward_wrapper, coordinates)
 
 
 class TestPBCSeeEachOther(unittest.TestCase):
-
     def setUp(self):
         self.ani1x = torchani.models.ANI1x()
         self.aev_computer = self.ani1x.aev_computer.to(torch.double)
 
     def testTranslationalInvariancePBC(self):
         coordinates = torch.tensor(
-            [[[0, 0, 0],
-              [1, 0, 0],
-              [0, 1, 0],
-              [0, 0, 1],
-              [0, 1, 1]]],
-            dtype=torch.double, requires_grad=True)
+            [[[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 1, 1]]],
+            dtype=torch.double,
+            requires_grad=True)
         cell = torch.eye(3, dtype=torch.double) * 2
         species = torch.tensor([[1, 0, 0, 0, 0]], dtype=torch.long)
         pbc = torch.ones(3, dtype=torch.uint8)
@@ -198,7 +214,8 @@ class TestPBCSeeEachOther(unittest.TestCase):
 
         for _ in range(100):
             translation = torch.randn(3, dtype=torch.double)
-            _, aev2 = self.aev_computer((species, coordinates + translation, cell, pbc))
+            _, aev2 = self.aev_computer(
+                (species, coordinates + translation, cell, pbc))
             self.assertTrue(torch.allclose(aev, aev2))
 
     def testPBCConnersSeeEachOther(self):
@@ -219,8 +236,10 @@ class TestPBCSeeEachOther(unittest.TestCase):
         ]
 
         for xyz2 in xyz2s:
-            coordinates = torch.stack([xyz1, xyz2]).to(torch.double).unsqueeze(0)
-            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
+            coordinates = torch.stack([xyz1,
+                                       xyz2]).to(torch.double).unsqueeze(0)
+            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
+                species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
             self.assertEqual(atom_index2.tolist(), [1])
 
@@ -237,7 +256,8 @@ class TestPBCSeeEachOther(unittest.TestCase):
             xyz2[i] = 9.9
 
             coordinates = torch.stack([xyz1, xyz2]).unsqueeze(0)
-            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
+            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
+                species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
             self.assertEqual(atom_index2.tolist(), [1])
 
@@ -257,14 +277,17 @@ class TestPBCSeeEachOther(unittest.TestCase):
                 xyz2[j] = new_j
 
             coordinates = torch.stack([xyz1, xyz2]).unsqueeze(0)
-            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
+            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
+                species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
             self.assertEqual(atom_index2.tolist(), [1])
 
     def testNonRectangularPBCConnersSeeEachOther(self):
         species = torch.tensor([[0, 0]])
-        cell = ase.geometry.cellpar_to_cell([10, 10, 10 * math.sqrt(2), 90, 45, 90])
-        cell = torch.tensor(ase.geometry.complete_cell(cell), dtype=torch.double)
+        cell = ase.geometry.cellpar_to_cell(
+            [10, 10, 10 * math.sqrt(2), 90, 45, 90])
+        cell = torch.tensor(ase.geometry.complete_cell(cell),
+                            dtype=torch.double)
         pbc = torch.ones(3, dtype=torch.uint8)
         allshifts = torchani.aev.compute_shifts(cell, pbc, 1)
 
@@ -272,41 +295,48 @@ class TestPBCSeeEachOther(unittest.TestCase):
         xyz2 = torch.tensor([10.0, 0.1, 0.1], dtype=torch.double)
 
         coordinates = torch.stack([xyz1, xyz2]).unsqueeze(0)
-        atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
+        atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
+            species == -1, coordinates, cell, allshifts, 1)
         self.assertEqual(atom_index1.tolist(), [0])
         self.assertEqual(atom_index2.tolist(), [1])
 
 
 class TestAEVOnBoundary(unittest.TestCase):
-
     def setUp(self):
         self.eps = 1e-9
-        cell = ase.geometry.cellpar_to_cell([100, 100, 100 * math.sqrt(2), 90, 45, 90])
-        self.cell = torch.tensor(ase.geometry.complete_cell(cell), dtype=torch.double)
+        cell = ase.geometry.cellpar_to_cell(
+            [100, 100, 100 * math.sqrt(2), 90, 45, 90])
+        self.cell = torch.tensor(ase.geometry.complete_cell(cell),
+                                 dtype=torch.double)
         self.inv_cell = torch.inverse(self.cell)
-        self.coordinates = torch.tensor([[[0.0, 0.0, 0.0],
-                                          [1.0, -0.1, -0.1],
-                                          [-0.1, 1.0, -0.1],
-                                          [-0.1, -0.1, 1.0],
-                                          [-1.0, -1.0, -1.0]]], dtype=torch.double)
+        self.coordinates = torch.tensor(
+            [[[0.0, 0.0, 0.0], [1.0, -0.1, -0.1], [-0.1, 1.0, -0.1],
+              [-0.1, -0.1, 1.0], [-1.0, -1.0, -1.0]]],
+            dtype=torch.double)
         self.species = torch.tensor([[1, 0, 0, 0]])
         self.pbc = torch.ones(3, dtype=torch.uint8)
         self.v1, self.v2, self.v3 = self.cell
-        self.center_coordinates = self.coordinates + 0.5 * (self.v1 + self.v2 + self.v3)
+        self.center_coordinates = self.coordinates + 0.5 * (
+            self.v1 + self.v2 + self.v3)
         ani1x = torchani.models.ANI1x()
         self.aev_computer = ani1x.aev_computer.to(torch.double)
-        _, self.aev = self.aev_computer((self.species, self.center_coordinates, self.cell, self.pbc))
+        _, self.aev = self.aev_computer(
+            (self.species, self.center_coordinates, self.cell, self.pbc))
 
     def assertInCell(self, coordinates):
         coordinates_cell = coordinates @ self.inv_cell
-        self.assertTrue(torch.allclose(coordinates, coordinates_cell @ self.cell))
-        in_cell = (coordinates_cell >= -self.eps) & (coordinates_cell <= 1 + self.eps)
+        self.assertTrue(
+            torch.allclose(coordinates, coordinates_cell @ self.cell))
+        in_cell = (coordinates_cell >= -self.eps) & (
+            coordinates_cell <= 1 + self.eps)
         self.assertTrue(in_cell.all())
 
     def assertNotInCell(self, coordinates):
         coordinates_cell = coordinates @ self.inv_cell
-        self.assertTrue(torch.allclose(coordinates, coordinates_cell @ self.cell))
-        in_cell = (coordinates_cell >= -self.eps) & (coordinates_cell <= 1 + self.eps)
+        self.assertTrue(
+            torch.allclose(coordinates, coordinates_cell @ self.cell))
+        in_cell = (coordinates_cell >= -self.eps) & (
+            coordinates_cell <= 1 + self.eps)
         self.assertFalse(in_cell.all())
 
     def testCornerSurfaceAndEdge(self):
@@ -315,51 +345,55 @@ class TestAEVOnBoundary(unittest.TestCase):
                 continue
             coordinates = self.coordinates + i * self.v1 + j * self.v2 + k * self.v3
             self.assertNotInCell(coordinates)
-            coordinates = torchani.utils.map2central(self.cell, coordinates, self.pbc)
+            coordinates = torchani.utils.map2central(self.cell, coordinates,
+                                                     self.pbc)
             self.assertInCell(coordinates)
-            _, aev = self.aev_computer((self.species, coordinates, self.cell, self.pbc))
+            _, aev = self.aev_computer(
+                (self.species, coordinates, self.cell, self.pbc))
             self.assertGreater(aev.abs().max().item(), 0)
             self.assertTrue(torch.allclose(aev, self.aev))
 
 
 class TestAEVOnBenzenePBC(unittest.TestCase):
-
     def setUp(self):
         ani1x = torchani.models.ANI1x()
         self.aev_computer = ani1x.aev_computer
-        filename = os.path.join(path, '../tools/generate-unit-test-expect/others/Benzene.cif')
+        filename = os.path.join(
+            path, '../tools/generate-unit-test-expect/others/Benzene.cif')
         benzene = ase.io.read(filename)
         self.cell = torch.tensor(benzene.get_cell(complete=True)).float()
-        self.pbc = torch.tensor(benzene.get_pbc().astype(numpy.uint8), dtype=torch.uint8)
-        species_to_tensor = torchani.utils.ChemicalSymbolsToInts(['H', 'C', 'N', 'O'])
-        self.species = species_to_tensor(benzene.get_chemical_symbols()).unsqueeze(0)
-        self.coordinates = torch.tensor(benzene.get_positions()).unsqueeze(0).float()
-        _, self.aev = self.aev_computer((self.species, self.coordinates, self.cell, self.pbc))
+        self.pbc = torch.tensor(benzene.get_pbc().astype(numpy.uint8),
+                                dtype=torch.uint8)
+        species_to_tensor = torchani.utils.ChemicalSymbolsToInts(
+            ['H', 'C', 'N', 'O'])
+        self.species = species_to_tensor(
+            benzene.get_chemical_symbols()).unsqueeze(0)
+        self.coordinates = torch.tensor(
+            benzene.get_positions()).unsqueeze(0).float()
+        _, self.aev = self.aev_computer(
+            (self.species, self.coordinates, self.cell, self.pbc))
         self.natoms = self.aev.shape[1]
 
     def testRepeat(self):
         tolerance = 5e-6
         c1, c2, c3 = self.cell
         species2 = self.species.repeat(1, 4)
-        coordinates2 = torch.cat([
-            self.coordinates,
-            self.coordinates + c1,
-            self.coordinates + 2 * c1,
-            self.coordinates + 3 * c1,
-        ], dim=1)
+        coordinates2 = torch.cat([self.coordinates,
+                                 self.coordinates + c1,
+                                 self.coordinates + 2 * c1,
+                                 self.coordinates + 3 * c1], dim=1)
         cell2 = torch.stack([4 * c1, c2, c3])
         _, aev2 = self.aev_computer((species2, coordinates2, cell2, self.pbc))
         for i in range(3):
-            aev3 = aev2[:, i * self.natoms: (i + 1) * self.natoms, :]
+            aev3 = aev2[:, i * self.natoms:(i + 1) * self.natoms, :]
             self.assertTrue(torch.allclose(self.aev, aev3, atol=tolerance))
 
     def testManualMirror(self):
         c1, c2, c3 = self.cell
-        species2 = self.species.repeat(1, 3 ** 3)
+        species2 = self.species.repeat(1, 3**3)
         coordinates2 = torch.cat([
             self.coordinates + i * c1 + j * c2 + k * c3
-            for i, j, k in itertools.product([0, -1, 1], repeat=3)
-        ], dim=1)
+            for i, j, k in itertools.product([0, -1, 1], repeat=3)], dim=1)
         _, aev2 = self.aev_computer((species2, coordinates2))
         aev2 = aev2[:, :self.natoms, :]
         self.assertTrue(torch.allclose(self.aev, aev2))

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -299,8 +299,7 @@ class TestAEVOnBoundary(unittest.TestCase):
     def assertInCell(self, coordinates):
         coordinates_cell = coordinates @ self.inv_cell
         self.assertTrue(torch.allclose(coordinates, coordinates_cell @ self.cell))
-        in_cell = (coordinates_cell >= -self.eps) & (
-            coordinates_cell <= 1 + self.eps)
+        in_cell = (coordinates_cell >= -self.eps) & (coordinates_cell <= 1 + self.eps)
         self.assertTrue(in_cell.all())
 
     def assertNotInCell(self, coordinates):

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -17,6 +17,7 @@ tolerance = 1e-5
 
 
 class TestAEV(unittest.TestCase):
+
     def setUp(self):
         ani1x = torchani.models.ANI1x()
         self.aev_computer = ani1x.aev_computer
@@ -29,8 +30,7 @@ class TestAEV(unittest.TestCase):
     def transform(self, x):
         return x
 
-    def assertAEVEqual(
-            self, expected_radial, expected_angular, aev, tolerance=tolerance):
+    def assertAEVEqual(self, expected_radial, expected_angular, aev, tolerance=tolerance):
         radial = aev[..., :self.radial_length]
         angular = aev[..., self.radial_length:]
         radial_diff = expected_radial - radial
@@ -62,43 +62,35 @@ class TestAEV(unittest.TestCase):
 
     def testBenzeneMD(self):
         for i in range(10):
-            datafile = os.path.join(path,
-                                    'test_data/benzene-md/{}.dat'.format(i))
+            datafile = os.path.join(path, 'test_data/benzene-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, expected_radial, expected_angular, _, _, cell, pbc \
                     = pickle.load(f)
                 coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
                 species = torch.from_numpy(species).unsqueeze(0)
-                expected_radial = torch.from_numpy(
-                    expected_radial).float().unsqueeze(0)
-                expected_angular = torch.from_numpy(
-                    expected_angular).float().unsqueeze(0)
+                expected_radial = torch.from_numpy(expected_radial).float().unsqueeze(0)
+                expected_angular = torch.from_numpy(expected_angular).float().unsqueeze(0)
                 cell = torch.from_numpy(cell).float()
                 pbc = torch.from_numpy(pbc)
-                coordinates = torchani.utils.map2central(
-                    cell, coordinates, pbc)
+                coordinates = torchani.utils.map2central(cell, coordinates, pbc)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 expected_radial = self.transform(expected_radial)
                 expected_angular = self.transform(expected_angular)
                 _, aev = self.aev_computer((species, coordinates, cell, pbc))
-                self.assertAEVEqual(
-                    expected_radial, expected_angular, aev, 5e-5)
+                self.assertAEVEqual(expected_radial, expected_angular, aev, 5e-5)
 
     def testTripeptideMD(self):
         tol = 5e-6
         for i in range(100):
-            datafile = os.path.join(path,
-                                    'test_data/tripeptide-md/{}.dat'.format(i))
+            datafile = os.path.join(path, 'test_data/tripeptide-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, expected_radial, expected_angular, _, _, _, _ \
                     = pickle.load(f)
                 coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
                 species = torch.from_numpy(species).unsqueeze(0)
-                expected_radial = torch.from_numpy(
-                    expected_radial).float().unsqueeze(0)
-                expected_angular = torch.from_numpy(
-                    expected_angular).float().unsqueeze(0)
+                expected_radial = torch.from_numpy(expected_radial).float().unsqueeze(0)
+                expected_angular = torch.from_numpy(expected_angular).float().unsqueeze(0)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 expected_radial = self.transform(expected_radial)
@@ -121,13 +113,11 @@ class TestAEV(unittest.TestCase):
                 species = self.transform(species)
                 radial = self.transform(radial)
                 angular = self.transform(angular)
-                species_coordinates.append(
-                    {'species': species, 'coordinates': coordinates})
+                species_coordinates.append({'species': species, 'coordinates': coordinates})
                 radial_angular.append((radial, angular))
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
-        _, aev = self.aev_computer((species_coordinates['species'],
-                                    species_coordinates['coordinates']))
+        _, aev = self.aev_computer((species_coordinates['species'], species_coordinates['coordinates']))
         start = 0
         for expected_radial, expected_angular in radial_angular:
             conformations = expected_radial.shape[0]
@@ -159,13 +149,11 @@ class TestAEV(unittest.TestCase):
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         # Create local copy of aev_computer to avoid interference with other
         # tests.
-        aev_computer = copy.deepcopy(self.aev_computer).to(device).to(
-            torch.float64)
+        aev_computer = copy.deepcopy(self.aev_computer).to(device).to(torch.float64)
         with open(datafile, 'rb') as f:
             data = pickle.load(f)
             for coordinates, species, _, _, _, _ in data:
-                coordinates = torch.from_numpy(coordinates).to(device).to(
-                    torch.float64)
+                coordinates = torch.from_numpy(coordinates).to(device).to(torch.float64)
                 coordinates.requires_grad_(True)
                 species = torch.from_numpy(species).to(device)
 
@@ -180,10 +168,12 @@ class TestAEV(unittest.TestCase):
                 def aev_forward_wrapper(coords):
                     # Return only the aev portion of the output.
                     return aev_computer((species, coords))[1]
-
                 # Sanity Check: Forward wrapper returns aev without error.
                 aev_forward_wrapper(coordinates)
-                torch.autograd.gradcheck(aev_forward_wrapper, coordinates)
+                torch.autograd.gradcheck(
+                    aev_forward_wrapper,
+                    coordinates
+                )
 
 
 class TestPBCSeeEachOther(unittest.TestCase):
@@ -192,11 +182,13 @@ class TestPBCSeeEachOther(unittest.TestCase):
         self.aev_computer = self.ani1x.aev_computer.to(torch.double)
 
     def testTranslationalInvariancePBC(self):
-        coordinates = torch.tensor([[[0, 0, 0],
-                                     [1, 0, 0],
-                                     [0, 1, 0],
-                                     [0, 0, 1],
-                                     [0, 1, 1]]], dtype=torch.double, requires_grad=True)
+        coordinates = torch.tensor(
+            [[[0, 0, 0],
+              [1, 0, 0],
+              [0, 1, 0],
+              [0, 0, 1],
+              [0, 1, 1]]],
+            dtype=torch.double, requires_grad=True)
         cell = torch.eye(3, dtype=torch.double) * 2
         species = torch.tensor([[1, 0, 0, 0, 0]], dtype=torch.long)
         pbc = torch.ones(3, dtype=torch.uint8)
@@ -205,8 +197,7 @@ class TestPBCSeeEachOther(unittest.TestCase):
 
         for _ in range(100):
             translation = torch.randn(3, dtype=torch.double)
-            _, aev2 = self.aev_computer(
-                (species, coordinates + translation, cell, pbc))
+            _, aev2 = self.aev_computer((species, coordinates + translation, cell, pbc))
             self.assertTrue(torch.allclose(aev, aev2))
 
     def testPBCConnersSeeEachOther(self):
@@ -223,13 +214,12 @@ class TestPBCSeeEachOther(unittest.TestCase):
             torch.tensor([9.9, 9.9, 0.0]),
             torch.tensor([0.0, 9.9, 9.9]),
             torch.tensor([9.9, 0.0, 9.9]),
-            torch.tensor([9.9, 9.9, 9.9])]
+            torch.tensor([9.9, 9.9, 9.9]),
+        ]
 
         for xyz2 in xyz2s:
-            coordinates = torch.stack([xyz1, xyz2]).to(
-                torch.double).unsqueeze(0)
-            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
-                species == -1, coordinates, cell, allshifts, 1)
+            coordinates = torch.stack([xyz1, xyz2]).to(torch.double).unsqueeze(0)
+            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
             self.assertEqual(atom_index2.tolist(), [1])
 
@@ -246,8 +236,7 @@ class TestPBCSeeEachOther(unittest.TestCase):
             xyz2[i] = 9.9
 
             coordinates = torch.stack([xyz1, xyz2]).unsqueeze(0)
-            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
-                species == -1, coordinates, cell, allshifts, 1)
+            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
             self.assertEqual(atom_index2.tolist(), [1])
 
@@ -267,17 +256,14 @@ class TestPBCSeeEachOther(unittest.TestCase):
                 xyz2[j] = new_j
 
             coordinates = torch.stack([xyz1, xyz2]).unsqueeze(0)
-            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
-                species == -1, coordinates, cell, allshifts, 1)
+            atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
             self.assertEqual(atom_index1.tolist(), [0])
             self.assertEqual(atom_index2.tolist(), [1])
 
     def testNonRectangularPBCConnersSeeEachOther(self):
         species = torch.tensor([[0, 0]])
-        cell = ase.geometry.cellpar_to_cell(
-            [10, 10, 10 * math.sqrt(2), 90, 45, 90])
-        cell = torch.tensor(ase.geometry.complete_cell(cell),
-                            dtype=torch.double)
+        cell = ase.geometry.cellpar_to_cell([10, 10, 10 * math.sqrt(2), 90, 45, 90])
+        cell = torch.tensor(ase.geometry.complete_cell(cell), dtype=torch.double)
         pbc = torch.ones(3, dtype=torch.uint8)
         allshifts = torchani.aev.compute_shifts(cell, pbc, 1)
 
@@ -285,19 +271,17 @@ class TestPBCSeeEachOther(unittest.TestCase):
         xyz2 = torch.tensor([10.0, 0.1, 0.1], dtype=torch.double)
 
         coordinates = torch.stack([xyz1, xyz2]).unsqueeze(0)
-        atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(
-            species == -1, coordinates, cell, allshifts, 1)
+        atom_index1, atom_index2, _ = torchani.aev.neighbor_pairs(species == -1, coordinates, cell, allshifts, 1)
         self.assertEqual(atom_index1.tolist(), [0])
         self.assertEqual(atom_index2.tolist(), [1])
 
 
 class TestAEVOnBoundary(unittest.TestCase):
+
     def setUp(self):
         self.eps = 1e-9
-        cell = ase.geometry.cellpar_to_cell(
-            [100, 100, 100 * math.sqrt(2), 90, 45, 90])
-        self.cell = torch.tensor(ase.geometry.complete_cell(cell),
-                                 dtype=torch.double)
+        cell = ase.geometry.cellpar_to_cell([100, 100, 100 * math.sqrt(2), 90, 45, 90])
+        self.cell = torch.tensor(ase.geometry.complete_cell(cell), dtype=torch.double)
         self.inv_cell = torch.inverse(self.cell)
         self.coordinates = torch.tensor([[[0.0, 0.0, 0.0],
                                           [1.0, -0.1, -0.1],
@@ -307,27 +291,22 @@ class TestAEVOnBoundary(unittest.TestCase):
         self.species = torch.tensor([[1, 0, 0, 0]])
         self.pbc = torch.ones(3, dtype=torch.uint8)
         self.v1, self.v2, self.v3 = self.cell
-        self.center_coordinates = self.coordinates + 0.5 * (
-            self.v1 + self.v2 + self.v3)
+        self.center_coordinates = self.coordinates + 0.5 * (self.v1 + self.v2 + self.v3)
         ani1x = torchani.models.ANI1x()
         self.aev_computer = ani1x.aev_computer.to(torch.double)
-        _, self.aev = self.aev_computer(
-            (self.species, self.center_coordinates, self.cell, self.pbc))
+        _, self.aev = self.aev_computer((self.species, self.center_coordinates, self.cell, self.pbc))
 
     def assertInCell(self, coordinates):
         coordinates_cell = coordinates @ self.inv_cell
-        self.assertTrue(
-            torch.allclose(coordinates, coordinates_cell @ self.cell))
+        self.assertTrue(torch.allclose(coordinates, coordinates_cell @ self.cell))
         in_cell = (coordinates_cell >= -self.eps) & (
             coordinates_cell <= 1 + self.eps)
         self.assertTrue(in_cell.all())
 
     def assertNotInCell(self, coordinates):
         coordinates_cell = coordinates @ self.inv_cell
-        self.assertTrue(
-            torch.allclose(coordinates, coordinates_cell @ self.cell))
-        in_cell = (coordinates_cell >= -self.eps) & (
-            coordinates_cell <= 1 + self.eps)
+        self.assertTrue(torch.allclose(coordinates, coordinates_cell @ self.cell))
+        in_cell = (coordinates_cell >= -self.eps) & (coordinates_cell <= 1 + self.eps)
         self.assertFalse(in_cell.all())
 
     def testCornerSurfaceAndEdge(self):
@@ -336,55 +315,51 @@ class TestAEVOnBoundary(unittest.TestCase):
                 continue
             coordinates = self.coordinates + i * self.v1 + j * self.v2 + k * self.v3
             self.assertNotInCell(coordinates)
-            coordinates = torchani.utils.map2central(self.cell, coordinates,
-                                                     self.pbc)
+            coordinates = torchani.utils.map2central(self.cell, coordinates, self.pbc)
             self.assertInCell(coordinates)
-            _, aev = self.aev_computer(
-                (self.species, coordinates, self.cell, self.pbc))
+            _, aev = self.aev_computer((self.species, coordinates, self.cell, self.pbc))
             self.assertGreater(aev.abs().max().item(), 0)
             self.assertTrue(torch.allclose(aev, self.aev))
 
 
 class TestAEVOnBenzenePBC(unittest.TestCase):
+
     def setUp(self):
         ani1x = torchani.models.ANI1x()
         self.aev_computer = ani1x.aev_computer
-        filename = os.path.join(
-            path, '../tools/generate-unit-test-expect/others/Benzene.cif')
+        filename = os.path.join(path, '../tools/generate-unit-test-expect/others/Benzene.cif')
         benzene = ase.io.read(filename)
         self.cell = torch.tensor(benzene.get_cell(complete=True)).float()
-        self.pbc = torch.tensor(benzene.get_pbc().astype(numpy.uint8),
-                                dtype=torch.uint8)
-        species_to_tensor = torchani.utils.ChemicalSymbolsToInts(
-            ['H', 'C', 'N', 'O'])
-        self.species = species_to_tensor(
-            benzene.get_chemical_symbols()).unsqueeze(0)
-        self.coordinates = torch.tensor(
-            benzene.get_positions()).unsqueeze(0).float()
-        _, self.aev = self.aev_computer(
-            (self.species, self.coordinates, self.cell, self.pbc))
+        self.pbc = torch.tensor(benzene.get_pbc().astype(numpy.uint8), dtype=torch.uint8)
+        species_to_tensor = torchani.utils.ChemicalSymbolsToInts(['H', 'C', 'N', 'O'])
+        self.species = species_to_tensor(benzene.get_chemical_symbols()).unsqueeze(0)
+        self.coordinates = torch.tensor(benzene.get_positions()).unsqueeze(0).float()
+        _, self.aev = self.aev_computer((self.species, self.coordinates, self.cell, self.pbc))
         self.natoms = self.aev.shape[1]
 
     def testRepeat(self):
         tolerance = 5e-6
         c1, c2, c3 = self.cell
         species2 = self.species.repeat(1, 4)
-        coordinates2 = torch.cat([self.coordinates,
-                                 self.coordinates + c1,
-                                 self.coordinates + 2 * c1,
-                                 self.coordinates + 3 * c1], dim=1)
+        coordinates2 = torch.cat([
+            self.coordinates,
+            self.coordinates + c1,
+            self.coordinates + 2 * c1,
+            self.coordinates + 3 * c1,
+        ], dim=1)
         cell2 = torch.stack([4 * c1, c2, c3])
         _, aev2 = self.aev_computer((species2, coordinates2, cell2, self.pbc))
         for i in range(3):
-            aev3 = aev2[:, i * self.natoms:(i + 1) * self.natoms, :]
+            aev3 = aev2[:, i * self.natoms: (i + 1) * self.natoms, :]
             self.assertTrue(torch.allclose(self.aev, aev3, atol=tolerance))
 
     def testManualMirror(self):
         c1, c2, c3 = self.cell
-        species2 = self.species.repeat(1, 3**3)
+        species2 = self.species.repeat(1, 3 ** 3)
         coordinates2 = torch.cat([
             self.coordinates + i * c1 + j * c2 + k * c3
-            for i, j, k in itertools.product([0, -1, 1], repeat=3)], dim=1)
+            for i, j, k in itertools.product([0, -1, 1], repeat=3)
+        ], dim=1)
         _, aev2 = self.aev_computer((species2, coordinates2))
         aev2 = aev2[:, :self.natoms, :]
         self.assertTrue(torch.allclose(self.aev, aev2))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,7 +14,6 @@ aev_computer = ani1x.aev_computer
 
 
 class TestData(unittest.TestCase):
-
     def setUp(self):
         self.ds = torchani.data.load_ani_dataset(dataset_path,
                                                  consts.species_to_tensor,
@@ -31,9 +30,18 @@ class TestData(unittest.TestCase):
         species3 = torch.randint(4, (10, 20), dtype=torch.long)
         coordinates3 = torch.randn(10, 20, 3)
         species_coordinates = torchani.utils.pad_atomic_properties([
-            {'species': species1, 'coordinates': coordinates1},
-            {'species': species2, 'coordinates': coordinates2},
-            {'species': species3, 'coordinates': coordinates3},
+            {
+                'species': species1,
+                'coordinates': coordinates1
+            },
+            {
+                'species': species2,
+                'coordinates': coordinates2
+            },
+            {
+                'species': species3,
+                'coordinates': coordinates3
+            },
         ])
         species = species_coordinates['species']
         coordinates = species_coordinates['coordinates']
@@ -51,7 +59,10 @@ class TestData(unittest.TestCase):
             self.assertGreater(conformations, 0)
             s_ = species[start:(start + conformations), ...]
             c_ = coordinates[start:(start + conformations), ...]
-            sc = torchani.utils.strip_redundant_padding({'species': s_, 'coordinates': c_})
+            sc = torchani.utils.strip_redundant_padding({
+                'species': s_,
+                'coordinates': c_
+            })
             s_ = sc['species']
             c_ = sc['coordinates']
             self._assertTensorEqual(s, s_)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,6 +14,7 @@ aev_computer = ani1x.aev_computer
 
 
 class TestData(unittest.TestCase):
+
     def setUp(self):
         self.ds = torchani.data.load_ani_dataset(dataset_path,
                                                  consts.species_to_tensor,
@@ -32,7 +33,8 @@ class TestData(unittest.TestCase):
         species_coordinates = torchani.utils.pad_atomic_properties([
             {'species': species1, 'coordinates': coordinates1},
             {'species': species2, 'coordinates': coordinates2},
-            {'species': species3, 'coordinates': coordinates3}])
+            {'species': species3, 'coordinates': coordinates3},
+        ])
         species = species_coordinates['species']
         coordinates = species_coordinates['coordinates']
         natoms = (species >= 0).to(torch.long).sum(1)
@@ -49,8 +51,7 @@ class TestData(unittest.TestCase):
             self.assertGreater(conformations, 0)
             s_ = species[start:(start + conformations), ...]
             c_ = coordinates[start:(start + conformations), ...]
-            sc = torchani.utils.strip_redundant_padding({
-                'species': s_, 'coordinates': c_})
+            sc = torchani.utils.strip_redundant_padding({'species': s_, 'coordinates': c_})
             s_ = sc['species']
             c_ = sc['coordinates']
             self._assertTensorEqual(s, s_)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,9 +8,9 @@ path = os.path.dirname(os.path.realpath(__file__))
 dataset_path = os.path.join(path, '../dataset/ani1-up_to_gdb4')
 dataset_path2 = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 batch_size = 256
-builtins = torchani.neurochem.Builtins()
-consts = builtins.consts
-aev_computer = builtins.aev_computer
+ani1x = torchani.models.ANI1x()
+consts = ani1x.consts
+aev_computer = ani1x.aev_computer
 
 
 class TestData(unittest.TestCase):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,19 +30,9 @@ class TestData(unittest.TestCase):
         species3 = torch.randint(4, (10, 20), dtype=torch.long)
         coordinates3 = torch.randn(10, 20, 3)
         species_coordinates = torchani.utils.pad_atomic_properties([
-            {
-                'species': species1,
-                'coordinates': coordinates1
-            },
-            {
-                'species': species2,
-                'coordinates': coordinates2
-            },
-            {
-                'species': species3,
-                'coordinates': coordinates3
-            },
-        ])
+            {'species': species1, 'coordinates': coordinates1},
+            {'species': species2, 'coordinates': coordinates2},
+            {'species': species3, 'coordinates': coordinates3}])
         species = species_coordinates['species']
         coordinates = species_coordinates['coordinates']
         natoms = (species >= 0).to(torch.long).sum(1)
@@ -60,9 +50,7 @@ class TestData(unittest.TestCase):
             s_ = species[start:(start + conformations), ...]
             c_ = coordinates[start:(start + conformations), ...]
             sc = torchani.utils.strip_redundant_padding({
-                'species': s_,
-                'coordinates': c_
-            })
+                'species': s_, 'coordinates': c_})
             s_ = sc['species']
             c_ = sc['coordinates']
             self._assertTensorEqual(s, s_)

--- a/tests/test_energies.py
+++ b/tests/test_energies.py
@@ -92,10 +92,8 @@ class TestEnergies(unittest.TestCase):
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 e = self.transform(e)
-                species_coordinates.append({
-                    'species': species,
-                    'coordinates': coordinates
-                })
+                species_coordinates.append(
+                    {'species': species, 'coordinates': coordinates})
                 energies.append(e)
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)

--- a/tests/test_energies.py
+++ b/tests/test_energies.py
@@ -5,13 +5,11 @@ import os
 import pickle
 import math
 
-
 path = os.path.dirname(os.path.realpath(__file__))
 N = 97
 
 
 class TestEnergies(unittest.TestCase):
-
     def setUp(self):
         self.tolerance = 5e-5
         ani1x = torchani.models.ANI1x()
@@ -44,15 +42,18 @@ class TestEnergies(unittest.TestCase):
     def testBenzeneMD(self):
         tolerance = 1e-5
         for i in range(10):
-            datafile = os.path.join(path, 'test_data/benzene-md/{}.dat'.format(i))
+            datafile = os.path.join(path,
+                                    'test_data/benzene-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, energies, _, cell, pbc \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
+                    0)
                 species = torch.from_numpy(species).unsqueeze(0)
                 cell = torch.from_numpy(cell).float()
                 pbc = torch.from_numpy(pbc)
-                coordinates = torchani.utils.map2central(cell, coordinates, pbc)
+                coordinates = torchani.utils.map2central(
+                    cell, coordinates, pbc)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 energies = self.transform(energies)
@@ -63,11 +64,13 @@ class TestEnergies(unittest.TestCase):
     def testTripeptideMD(self):
         tolerance = 2e-4
         for i in range(100):
-            datafile = os.path.join(path, 'test_data/tripeptide-md/{}.dat'.format(i))
+            datafile = os.path.join(path,
+                                    'test_data/tripeptide-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, energies, _, _, _ \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
+                    0)
                 species = torch.from_numpy(species).unsqueeze(0)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
@@ -89,12 +92,16 @@ class TestEnergies(unittest.TestCase):
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 e = self.transform(e)
-                species_coordinates.append({'species': species, 'coordinates': coordinates})
+                species_coordinates.append({
+                    'species': species,
+                    'coordinates': coordinates
+                })
                 energies.append(e)
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
         energies = torch.cat(energies)
-        _, energies_ = self.model((species_coordinates['species'], species_coordinates['coordinates']))
+        _, energies_ = self.model((species_coordinates['species'],
+                                   species_coordinates['coordinates']))
         max_diff = (energies - energies_).abs().max().item()
         self.assertLess(max_diff, self.tolerance)
 

--- a/tests/test_energies.py
+++ b/tests/test_energies.py
@@ -5,11 +5,13 @@ import os
 import pickle
 import math
 
+
 path = os.path.dirname(os.path.realpath(__file__))
 N = 97
 
 
 class TestEnergies(unittest.TestCase):
+
     def setUp(self):
         self.tolerance = 5e-5
         ani1x = torchani.models.ANI1x()
@@ -42,18 +44,15 @@ class TestEnergies(unittest.TestCase):
     def testBenzeneMD(self):
         tolerance = 1e-5
         for i in range(10):
-            datafile = os.path.join(path,
-                                    'test_data/benzene-md/{}.dat'.format(i))
+            datafile = os.path.join(path, 'test_data/benzene-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, energies, _, cell, pbc \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
-                    0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
                 species = torch.from_numpy(species).unsqueeze(0)
                 cell = torch.from_numpy(cell).float()
                 pbc = torch.from_numpy(pbc)
-                coordinates = torchani.utils.map2central(
-                    cell, coordinates, pbc)
+                coordinates = torchani.utils.map2central(cell, coordinates, pbc)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 energies = self.transform(energies)
@@ -64,13 +63,11 @@ class TestEnergies(unittest.TestCase):
     def testTripeptideMD(self):
         tolerance = 2e-4
         for i in range(100):
-            datafile = os.path.join(path,
-                                    'test_data/tripeptide-md/{}.dat'.format(i))
+            datafile = os.path.join(path, 'test_data/tripeptide-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, energies, _, _, _ \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
-                    0)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0)
                 species = torch.from_numpy(species).unsqueeze(0)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
@@ -92,14 +89,12 @@ class TestEnergies(unittest.TestCase):
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 e = self.transform(e)
-                species_coordinates.append(
-                    {'species': species, 'coordinates': coordinates})
+                species_coordinates.append({'species': species, 'coordinates': coordinates})
                 energies.append(e)
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
         energies = torch.cat(energies)
-        _, energies_ = self.model((species_coordinates['species'],
-                                   species_coordinates['coordinates']))
+        _, energies_ = self.model((species_coordinates['species'], species_coordinates['coordinates']))
         max_diff = (energies - energies_).abs().max().item()
         self.assertLess(max_diff, self.tolerance)
 

--- a/tests/test_energies.py
+++ b/tests/test_energies.py
@@ -14,11 +14,11 @@ class TestEnergies(unittest.TestCase):
 
     def setUp(self):
         self.tolerance = 5e-5
-        builtins = torchani.neurochem.Builtins()
-        self.aev_computer = builtins.aev_computer
-        nnp = builtins.models[0]
-        shift_energy = builtins.energy_shifter
-        self.model = torch.nn.Sequential(self.aev_computer, nnp, shift_energy)
+        ani1x = torchani.models.ANI1x()
+        aev_computer = ani1x.aev_computer
+        nnp = ani1x.neural_networks[0]
+        shift_energy = ani1x.energy_shifter
+        self.model = torch.nn.Sequential(aev_computer, nnp, shift_energy)
 
     def random_skip(self):
         return False

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -9,6 +9,7 @@ N = 10
 
 
 class TestEnsemble(unittest.TestCase):
+
     def setUp(self):
         self.tol = 1e-5
         self.conformations = 20

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -15,17 +15,17 @@ class TestEnsemble(unittest.TestCase):
         self.conformations = 20
 
     def _test_molecule(self, coordinates, species):
-        builtins = torchani.neurochem.Builtins()
+        ani1x = torchani.models.ANI1x()
         coordinates.requires_grad_(True)
-        aev = builtins.aev_computer
-        ensemble = builtins.models
-        models = [torch.nn.Sequential(aev, m) for m in ensemble]
-        ensemble = torch.nn.Sequential(aev, ensemble)
+        aev = ani1x.aev_computer
+        model_iterator = ani1x.neural_networks
+        model_list = [torch.nn.Sequential(aev, m) for m in model_iterator]
+        ensemble = torch.nn.Sequential(aev, model_iterator)
 
         _, energy1 = ensemble((species, coordinates))
         force1 = torch.autograd.grad(energy1.sum(), coordinates)[0]
-        energy2 = [m((species, coordinates))[1] for m in models]
-        energy2 = sum(energy2) / len(models)
+        energy2 = [m((species, coordinates))[1] for m in model_list]
+        energy2 = sum(energy2) / len(model_list)
         force2 = torch.autograd.grad(energy2.sum(), coordinates)[0]
         energy_diff = (energy1 - energy2).abs().max().item()
         force_diff = (force1 - force2).abs().max().item()

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -9,7 +9,6 @@ N = 10
 
 
 class TestEnsemble(unittest.TestCase):
-
     def setUp(self):
         self.tol = 1e-5
         self.conformations = 20

--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -9,6 +9,7 @@ N = 97
 
 
 class TestForce(unittest.TestCase):
+
     def setUp(self):
         self.tolerance = 1e-5
         ani1x = torchani.models.ANI1x()
@@ -54,38 +55,29 @@ class TestForce(unittest.TestCase):
                 species = self.transform(species)
                 forces = self.transform(forces)
                 coordinates.requires_grad_(True)
-                species_coordinates.append({
-                    'species': species,
-                    'coordinates': coordinates
-                })
+                species_coordinates.append({'species': species, 'coordinates': coordinates})
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
-        _, energies = self.model((species_coordinates['species'],
-                                  species_coordinates['coordinates']))
+        _, energies = self.model((species_coordinates['species'], species_coordinates['coordinates']))
         energies = energies.sum()
         for coordinates, forces in coordinates_forces:
-            derivative = torch.autograd.grad(energies,
-                                             coordinates,
-                                             retain_graph=True)[0]
+            derivative = torch.autograd.grad(energies, coordinates, retain_graph=True)[0]
             max_diff = (forces + derivative).abs().max().item()
             self.assertLess(max_diff, self.tolerance)
 
     def testBenzeneMD(self):
         tolerance = 1e-5
         for i in range(10):
-            datafile = os.path.join(path,
-                                    'test_data/benzene-md/{}.dat'.format(i))
+            datafile = os.path.join(path, 'test_data/benzene-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, _, forces, cell, pbc \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
-                    0).requires_grad_(True)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0).requires_grad_(True)
                 species = torch.from_numpy(species).unsqueeze(0)
                 cell = torch.from_numpy(cell).float()
                 pbc = torch.from_numpy(pbc)
                 forces = torch.from_numpy(forces)
-                coordinates = torchani.utils.map2central(
-                    cell, coordinates, pbc)
+                coordinates = torchani.utils.map2central(cell, coordinates, pbc)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 forces = self.transform(forces)
@@ -98,13 +90,11 @@ class TestForce(unittest.TestCase):
     def testTripeptideMD(self):
         tolerance = 2e-6
         for i in range(100):
-            datafile = os.path.join(path,
-                                    'test_data/tripeptide-md/{}.dat'.format(i))
+            datafile = os.path.join(path, 'test_data/tripeptide-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, _, forces, _, _ \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
-                    0).requires_grad_(True)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0).requires_grad_(True)
                 species = torch.from_numpy(species).unsqueeze(0)
                 forces = torch.from_numpy(forces)
                 coordinates = self.transform(coordinates)

--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -12,9 +12,9 @@ class TestForce(unittest.TestCase):
 
     def setUp(self):
         self.tolerance = 1e-5
-        builtins = torchani.neurochem.Builtins()
-        self.aev_computer = builtins.aev_computer
-        nnp = builtins.models[0]
+        ani1x = torchani.models.ANI1x()
+        self.aev_computer = ani1x.aev_computer
+        nnp = ani1x.neural_networks[0]
         self.model = torch.nn.Sequential(self.aev_computer, nnp)
 
     def random_skip(self):

--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -9,7 +9,6 @@ N = 97
 
 
 class TestForce(unittest.TestCase):
-
     def setUp(self):
         self.tolerance = 1e-5
         ani1x = torchani.models.ANI1x()
@@ -55,13 +54,18 @@ class TestForce(unittest.TestCase):
                 species = self.transform(species)
                 forces = self.transform(forces)
                 coordinates.requires_grad_(True)
-                species_coordinates.append({'species': species, 'coordinates': coordinates})
+                species_coordinates.append({
+                    'species': species,
+                    'coordinates': coordinates
+                })
         species_coordinates = torchani.utils.pad_atomic_properties(
             species_coordinates)
-        _, energies = self.model((species_coordinates['species'], species_coordinates['coordinates']))
+        _, energies = self.model((species_coordinates['species'],
+                                  species_coordinates['coordinates']))
         energies = energies.sum()
         for coordinates, forces in coordinates_forces:
-            derivative = torch.autograd.grad(energies, coordinates,
+            derivative = torch.autograd.grad(energies,
+                                             coordinates,
                                              retain_graph=True)[0]
             max_diff = (forces + derivative).abs().max().item()
             self.assertLess(max_diff, self.tolerance)
@@ -69,16 +73,19 @@ class TestForce(unittest.TestCase):
     def testBenzeneMD(self):
         tolerance = 1e-5
         for i in range(10):
-            datafile = os.path.join(path, 'test_data/benzene-md/{}.dat'.format(i))
+            datafile = os.path.join(path,
+                                    'test_data/benzene-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, _, forces, cell, pbc \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0).requires_grad_(True)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
+                    0).requires_grad_(True)
                 species = torch.from_numpy(species).unsqueeze(0)
                 cell = torch.from_numpy(cell).float()
                 pbc = torch.from_numpy(pbc)
                 forces = torch.from_numpy(forces)
-                coordinates = torchani.utils.map2central(cell, coordinates, pbc)
+                coordinates = torchani.utils.map2central(
+                    cell, coordinates, pbc)
                 coordinates = self.transform(coordinates)
                 species = self.transform(species)
                 forces = self.transform(forces)
@@ -91,11 +98,13 @@ class TestForce(unittest.TestCase):
     def testTripeptideMD(self):
         tolerance = 2e-6
         for i in range(100):
-            datafile = os.path.join(path, 'test_data/tripeptide-md/{}.dat'.format(i))
+            datafile = os.path.join(path,
+                                    'test_data/tripeptide-md/{}.dat'.format(i))
             with open(datafile, 'rb') as f:
                 coordinates, species, _, _, _, forces, _, _ \
                     = pickle.load(f)
-                coordinates = torch.from_numpy(coordinates).float().unsqueeze(0).requires_grad_(True)
+                coordinates = torch.from_numpy(coordinates).float().unsqueeze(
+                    0).requires_grad_(True)
                 species = torch.from_numpy(species).unsqueeze(0)
                 forces = torch.from_numpy(forces)
                 coordinates = self.transform(coordinates)

--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -61,7 +61,8 @@ class TestForce(unittest.TestCase):
         _, energies = self.model((species_coordinates['species'], species_coordinates['coordinates']))
         energies = energies.sum()
         for coordinates, forces in coordinates_forces:
-            derivative = torch.autograd.grad(energies, coordinates, retain_graph=True)[0]
+            derivative = torch.autograd.grad(energies, coordinates,
+                                             retain_graph=True)[0]
             max_diff = (forces + derivative).abs().max().item()
             self.assertLess(max_diff, self.tolerance)
 

--- a/tests/test_ignite.py
+++ b/tests/test_ignite.py
@@ -14,14 +14,15 @@ threshold = 1e-5
 
 
 class TestIgnite(unittest.TestCase):
-
     def testIgnite(self):
         ani1x = torchani.models.ANI1x()
         aev_computer = ani1x.aev_computer
         nnp = copy.deepcopy(ani1x.neural_networks[0])
         shift_energy = ani1x.energy_shifter
         ds = torchani.data.BatchedANIDataset(
-            path, ani1x.consts.species_to_tensor, batchsize,
+            path,
+            ani1x.consts.species_to_tensor,
+            batchsize,
             transform=[shift_energy.subtract_from_dataset],
             device=aev_computer.EtaR.device)
         ds = torch.utils.data.Subset(ds, [0])
@@ -34,13 +35,11 @@ class TestIgnite(unittest.TestCase):
         container = torchani.ignite.Container({'energies': model})
         optimizer = torch.optim.Adam(container.parameters())
         loss = torchani.ignite.TransformedLoss(
-            torchani.ignite.MSELoss('energies'),
-            lambda x: torch.exp(x) - 1)
-        trainer = create_supervised_trainer(
-            container, optimizer, loss)
-        evaluator = create_supervised_evaluator(container, metrics={
-            'RMSE': torchani.ignite.RMSEMetric('energies')
-        })
+            torchani.ignite.MSELoss('energies'), lambda x: torch.exp(x) - 1)
+        trainer = create_supervised_trainer(container, optimizer, loss)
+        evaluator = create_supervised_evaluator(
+            container,
+            metrics={'RMSE': torchani.ignite.RMSEMetric('energies')})
 
         @trainer.on(Events.COMPLETED)
         def completes(trainer):

--- a/tests/test_ignite.py
+++ b/tests/test_ignite.py
@@ -16,12 +16,12 @@ threshold = 1e-5
 class TestIgnite(unittest.TestCase):
 
     def testIgnite(self):
-        builtins = torchani.neurochem.Builtins()
-        aev_computer = builtins.aev_computer
-        nnp = copy.deepcopy(builtins.models[0])
-        shift_energy = builtins.energy_shifter
+        ani1x = torchani.models.ANI1x()
+        aev_computer = ani1x.aev_computer
+        nnp = copy.deepcopy(ani1x.neural_networks[0])
+        shift_energy = ani1x.energy_shifter
         ds = torchani.data.BatchedANIDataset(
-            path, builtins.consts.species_to_tensor, batchsize,
+            path, ani1x.consts.species_to_tensor, batchsize,
             transform=[shift_energy.subtract_from_dataset],
             device=aev_computer.EtaR.device)
         ds = torch.utils.data.Subset(ds, [0])

--- a/tests/test_ignite.py
+++ b/tests/test_ignite.py
@@ -14,15 +14,14 @@ threshold = 1e-5
 
 
 class TestIgnite(unittest.TestCase):
+
     def testIgnite(self):
         ani1x = torchani.models.ANI1x()
         aev_computer = ani1x.aev_computer
         nnp = copy.deepcopy(ani1x.neural_networks[0])
         shift_energy = ani1x.energy_shifter
         ds = torchani.data.BatchedANIDataset(
-            path,
-            ani1x.consts.species_to_tensor,
-            batchsize,
+            path, ani1x.consts.species_to_tensor, batchsize,
             transform=[shift_energy.subtract_from_dataset],
             device=aev_computer.EtaR.device)
         ds = torch.utils.data.Subset(ds, [0])
@@ -35,11 +34,13 @@ class TestIgnite(unittest.TestCase):
         container = torchani.ignite.Container({'energies': model})
         optimizer = torch.optim.Adam(container.parameters())
         loss = torchani.ignite.TransformedLoss(
-            torchani.ignite.MSELoss('energies'), lambda x: torch.exp(x) - 1)
-        trainer = create_supervised_trainer(container, optimizer, loss)
-        evaluator = create_supervised_evaluator(
-            container,
-            metrics={'RMSE': torchani.ignite.RMSEMetric('energies')})
+            torchani.ignite.MSELoss('energies'),
+            lambda x: torch.exp(x) - 1)
+        trainer = create_supervised_trainer(
+            container, optimizer, loss)
+        evaluator = create_supervised_evaluator(container, metrics={
+            'RMSE': torchani.ignite.RMSEMetric('energies')
+        })
 
         @trainer.on(Events.COMPLETED)
         def completes(trainer):

--- a/tests/test_structure_optim.py
+++ b/tests/test_structure_optim.py
@@ -6,10 +6,12 @@ import copy
 import pickle
 from ase.optimize import BFGS
 
+
 path = os.path.dirname(os.path.realpath(__file__))
 
 
 class TestStructureOptimization(unittest.TestCase):
+
     def setUp(self):
         self.tolerance = 1e-6
         self.ani1x = torchani.models.ANI1x()

--- a/tests/test_structure_optim.py
+++ b/tests/test_structure_optim.py
@@ -6,12 +6,10 @@ import copy
 import pickle
 from ase.optimize import BFGS
 
-
 path = os.path.dirname(os.path.realpath(__file__))
 
 
 class TestStructureOptimization(unittest.TestCase):
-
     def setUp(self):
         self.tolerance = 1e-6
         self.ani1x = torchani.models.ANI1x()

--- a/tests/test_structure_optim.py
+++ b/tests/test_structure_optim.py
@@ -14,10 +14,10 @@ class TestStructureOptimization(unittest.TestCase):
 
     def setUp(self):
         self.tolerance = 1e-6
-        self.builtin = torchani.neurochem.Builtins()
+        self.ani1x = torchani.models.ANI1x()
         self.calculator = torchani.ase.Calculator(
-            self.builtin.species, self.builtin.aev_computer,
-            self.builtin.models[0], self.builtin.energy_shifter)
+            self.ani1x.species, self.ani1x.aev_computer,
+            self.ani1x.neural_networks[0], self.ani1x.energy_shifter)
 
     def testRMSE(self):
         datafile = os.path.join(path, 'test_data/NeuroChemOptimized/all')

--- a/tools/inference-benchmark.py
+++ b/tools/inference-benchmark.py
@@ -18,11 +18,11 @@ parser = parser.parse_args()
 
 # set up benchmark
 device = torch.device(parser.device)
-builtins = torchani.neurochem.Builtins()
+ani1x = torchani.models.ANI1x()
 nnp = torch.nn.Sequential(
-    builtins.aev_computer,
-    builtins.models[0],
-    builtins.energy_shifter
+    ani1x.aev_computer,
+    ani1x.models[0],
+    ani1x.energy_shifter
 ).to(device)
 
 
@@ -54,7 +54,7 @@ class XYZ:
                 atom_count -= 1
                 if atom_count == 0:
                     state = 'ready'
-                    species = builtins.consts.species_to_tensor(species) \
+                    species = ani1x.consts.species_to_tensor(species) \
                                       .to(device)
                     coordinates = torch.tensor(coordinates, device=device)
                     self.mols.append((species, coordinates))

--- a/tools/inference-benchmark.py
+++ b/tools/inference-benchmark.py
@@ -4,31 +4,28 @@ import torch
 import timeit
 import tqdm
 
-
 # parse command line arguments
 parser = argparse.ArgumentParser()
-parser.add_argument('filename',
-                    help='Path to the xyz file.')
-parser.add_argument('-d', '--device',
+parser.add_argument('filename', help='Path to the xyz file.')
+parser.add_argument('-d',
+                    '--device',
                     help='Device of modules and tensors',
                     default=('cuda' if torch.cuda.is_available() else 'cpu'))
-parser.add_argument('--tqdm', dest='tqdm', action='store_true',
+parser.add_argument('--tqdm',
+                    dest='tqdm',
+                    action='store_true',
                     help='Whether to use tqdm to display progress')
 parser = parser.parse_args()
 
 # set up benchmark
 device = torch.device(parser.device)
 ani1x = torchani.models.ANI1x()
-nnp = torch.nn.Sequential(
-    ani1x.aev_computer,
-    ani1x.models[0],
-    ani1x.energy_shifter
-).to(device)
+nnp = torch.nn.Sequential(ani1x.aev_computer, ani1x.models[0],
+                          ani1x.energy_shifter).to(device)
 
 
 # load XYZ files
 class XYZ:
-
     def __init__(self, filename):
         with open(filename, 'r') as f:
             lines = f.readlines()
@@ -55,7 +52,7 @@ class XYZ:
                 if atom_count == 0:
                     state = 'ready'
                     species = ani1x.consts.species_to_tensor(species) \
-                                      .to(device)
+                        .to(device)
                     coordinates = torch.tensor(coordinates, device=device)
                     self.mols.append((species, coordinates))
                     coordinates = []

--- a/tools/inference-benchmark.py
+++ b/tools/inference-benchmark.py
@@ -4,28 +4,31 @@ import torch
 import timeit
 import tqdm
 
+
 # parse command line arguments
 parser = argparse.ArgumentParser()
-parser.add_argument('filename', help='Path to the xyz file.')
-parser.add_argument('-d',
-                    '--device',
+parser.add_argument('filename',
+                    help='Path to the xyz file.')
+parser.add_argument('-d', '--device',
                     help='Device of modules and tensors',
                     default=('cuda' if torch.cuda.is_available() else 'cpu'))
-parser.add_argument('--tqdm',
-                    dest='tqdm',
-                    action='store_true',
+parser.add_argument('--tqdm', dest='tqdm', action='store_true',
                     help='Whether to use tqdm to display progress')
 parser = parser.parse_args()
 
 # set up benchmark
 device = torch.device(parser.device)
 ani1x = torchani.models.ANI1x()
-nnp = torch.nn.Sequential(ani1x.aev_computer, ani1x.neural_networks[0],
-                          ani1x.energy_shifter).to(device)
+nnp = torch.nn.Sequential(
+    ani1x.aev_computer,
+    ani1x.neural_networks[0],
+    ani1x.energy_shifter
+).to(device)
 
 
 # load XYZ files
 class XYZ:
+
     def __init__(self, filename):
         with open(filename, 'r') as f:
             lines = f.readlines()

--- a/tools/inference-benchmark.py
+++ b/tools/inference-benchmark.py
@@ -20,7 +20,7 @@ parser = parser.parse_args()
 # set up benchmark
 device = torch.device(parser.device)
 ani1x = torchani.models.ANI1x()
-nnp = torch.nn.Sequential(ani1x.aev_computer, ani1x.models[0],
+nnp = torch.nn.Sequential(ani1x.aev_computer, ani1x.neural_networks[0],
                           ani1x.energy_shifter).to(device)
 
 

--- a/tools/neurochem-test.py
+++ b/tools/neurochem-test.py
@@ -6,7 +6,7 @@ import pickle
 import argparse
 
 
-builtins = torchani.neurochem.Builtins()
+ani1x = torchani.models.ANI1x()
 
 # parse command line arguments
 parser = argparse.ArgumentParser()
@@ -22,13 +22,13 @@ parser.add_argument('--batch_size',
                     default=1024, type=int)
 parser.add_argument('--const_file',
                     help='File storing constants',
-                    default=builtins.const_file)
+                    default=ani1x.const_file)
 parser.add_argument('--sae_file',
                     help='File storing self atomic energies',
-                    default=builtins.sae_file)
+                    default=ani1x.sae_file)
 parser.add_argument('--network_dir',
                     help='Directory or prefix of directories storing networks',
-                    default=builtins.ensemble_prefix + '0/networks')
+                    default=ani1x.ensemble_prefix + '0/networks')
 parser.add_argument('--compare_with',
                     help='The TorchANI model to compare with', default=None)
 parser = parser.parse_args()

--- a/tools/training-benchmark-with-aevcache.py
+++ b/tools/training-benchmark-with-aevcache.py
@@ -16,10 +16,10 @@ parser = parser.parse_args()
 
 # set up benchmark
 device = torch.device(parser.device)
-builtins = torchani.neurochem.Builtins()
-consts = builtins.consts
-aev_computer = builtins.aev_computer
-shift_energy = builtins.energy_shifter
+ani1x = torchani.models.ANI1x()
+consts = ani1x.consts
+aev_computer = ani1x.aev_computer
+shift_energy = ani1x.energy_shifter
 
 
 def atomic():

--- a/tools/training-benchmark.py
+++ b/tools/training-benchmark.py
@@ -20,10 +20,10 @@ parser = parser.parse_args()
 
 # set up benchmark
 device = torch.device(parser.device)
-builtins = torchani.neurochem.Builtins()
-consts = builtins.consts
-aev_computer = builtins.aev_computer
-shift_energy = builtins.energy_shifter
+ani1x = torchani.models.ANI1x()
+consts = ani1x.consts
+aev_computer = ani1x.aev_computer
+shift_energy = ani1x.energy_shifter
 
 
 def atomic():

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -414,7 +414,7 @@ class SparseAEVCacheLoader(AEVCacheLoader):
         return encoded_species, encoded_aev
 
 
-builtin = neurochem.Builtins()
+ani1x = neurochem.models.ANI1x()
 
 
 def create_aev_cache(dataset, aev_computer, output, progress_bar=True, encoder=lambda *x: x):
@@ -471,16 +471,16 @@ def _cache_aev(output, dataset_path, batchsize, device, constfile,
 
 
 def cache_aev(output, dataset_path, batchsize, device=default_device,
-              constfile=builtin.const_file, subtract_sae=False,
-              sae_file=builtin.sae_file, enable_tqdm=True, **kwargs):
+              constfile=ani1x.const_file, subtract_sae=False,
+              sae_file=ani1x.sae_file, enable_tqdm=True, **kwargs):
     _cache_aev(output, dataset_path, batchsize, device, constfile,
                subtract_sae, sae_file, enable_tqdm, AEVCacheLoader.encode_aev,
                **kwargs)
 
 
 def cache_sparse_aev(output, dataset_path, batchsize, device=default_device,
-                     constfile=builtin.const_file, subtract_sae=False,
-                     sae_file=builtin.sae_file, enable_tqdm=True, **kwargs):
+                     constfile=ani1x.const_file, subtract_sae=False,
+                     sae_file=ani1x.sae_file, enable_tqdm=True, **kwargs):
     _cache_aev(output, dataset_path, batchsize, device, constfile,
                subtract_sae, sae_file, enable_tqdm,
                SparseAEVCacheLoader.encode_aev, **kwargs)

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -6,7 +6,7 @@ from os.path import join, isfile, isdir
 import os
 from ._pyanitools import anidataloader
 import torch
-from .. import utils, neurochem, aev
+from .. import utils, neurochem, aev, models
 import pickle
 import numpy as np
 from scipy.sparse import bsr_matrix
@@ -414,7 +414,7 @@ class SparseAEVCacheLoader(AEVCacheLoader):
         return encoded_species, encoded_aev
 
 
-ani1x = neurochem.models.ANI1x()
+ani1x = models.ANI1x()
 
 
 def create_aev_cache(dataset, aev_computer, output, progress_bar=True, encoder=lambda *x: x):

--- a/torchani/data/cache_aev.py
+++ b/torchani/data/cache_aev.py
@@ -5,9 +5,8 @@ computed aevs. Use the ``-h`` option for help.
 """
 
 import torch
-from . import cache_aev, cache_sparse_aev, default_device
-from ..models import ANI1x
-ani1x = ANI1x()
+from . import cache_aev, cache_sparse_aev, ani1x, default_device
+
 
 if __name__ == '__main__':
     import argparse

--- a/torchani/data/cache_aev.py
+++ b/torchani/data/cache_aev.py
@@ -5,8 +5,9 @@ computed aevs. Use the ``-h`` option for help.
 """
 
 import torch
-from . import cache_aev, cache_sparse_aev, builtin, default_device
-
+from . import cache_aev, cache_sparse_aev, default_device
+from ..models import ANI1x
+ani1x = ANI1x()
 
 if __name__ == '__main__':
     import argparse
@@ -19,7 +20,7 @@ if __name__ == '__main__':
     parser.add_argument('batchsize', help='batch size', type=int)
     parser.add_argument('--constfile',
                         help='Path of the constant file `.params`',
-                        default=builtin.const_file)
+                        default=ani1x.const_file)
     parser.add_argument('--properties', nargs='+',
                         help='Output properties to load.`',
                         default=['energies'])
@@ -35,7 +36,7 @@ if __name__ == '__main__':
                         help='Whether to subtrace self atomic energies',
                         default=None, action='store_true')
     parser.add_argument('--sae-file', help='Path to SAE file',
-                        default=builtin.sae_file)
+                        default=ani1x.sae_file)
     parser = parser.parse_args()
 
     cache_aev(parser.output, parser.dataset, parser.batchsize, parser.device,

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -186,14 +186,15 @@ class ANI1x(BuiltinNet):
             builtin constants
         neural_networks (:class:`torchani.Ensemble`): Ensemble of models
     """
-    def __init__(self,
-                 parent_name='.'.join(__name__.split('.')[:-1]),
-                 const_file_path='resources/ani-1x_8x'
-                 '/rHCNO-5.2R_16-3.5A_a4-8.params',
-                 sae_file_path='resources/ani-1x_8x/sae_linfit.dat',
-                 ensemble_size=8,
-                 ensemble_prefix_path='resources/ani-1x_8x/train'):
-        super(ANI1x, self).__init__()
+
+    def __init__(self):
+        super(ANI1x, self).__init__(
+            parent_name='.'.join(__name__.split('.')[:-1]),
+            const_file_path='resources/ani-1x_8x'
+            '/rHCNO-5.2R_16-3.5A_a4-8.params',
+            sae_file_path='resources/ani-1x_8x/sae_linfit.dat',
+            ensemble_size=8,
+            ensemble_prefix_path='resources/ani-1x_8x/train')
 
 
 class ANI1ccx(BuiltinNet):
@@ -223,11 +224,12 @@ class ANI1ccx(BuiltinNet):
             builtin constants
         neural_networks (:class:`torchani.Ensemble`): Ensemble of models
     """
-    def __init__(self,
-                 parent_name='.'.join(__name__.split('.')[:-1]),
-                 const_file_path='resources/ani-1ccx_8x'
-                 '/rHCNO-5.2R_16-3.5A_a4-8.params',
-                 sae_file_path='resources/ani-1ccx_8x/sae_linfit.dat',
-                 ensemble_size=8,
-                 ensemble_prefix_path='resources/ani-1ccx_8x/train'):
-        super(ANI1ccx, self).__init__()
+
+    def __init__(self):
+        super(ANI1ccx, self).__init__(
+            parent_name='.'.join(__name__.split('.')[:-1]),
+            const_file_path='resources/ani-1ccx_8x'
+            '/rHCNO-5.2R_16-3.5A_a4-8.params',
+            sae_file_path='resources/ani-1ccx_8x/sae_linfit.dat',
+            ensemble_size=8,
+            ensemble_prefix_path='resources/ani-1ccx_8x/train')

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -201,7 +201,7 @@ class ANI1x(BuiltinNet):
 
 
 class ANI1ccx(BuiltinNet):
-    """The ANI-1x model as in `ani-1ccx_8x on GitHub`_ and `Transfer Learning Paper`_.
+    """The ANI-1ccx model as in `ani-1ccx_8x on GitHub`_ and `Transfer Learning Paper`_.
 
     The ANI-1ccx model is an ensemble of 8 networks that was trained
     on the ANI-1ccx dataset, using transfer learning. The target accuracy

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -33,7 +33,7 @@ from . import neurochem
 from .aev import AEVComputer
 
 
-# TODO: Delete BuiltinModels in a future release, it is DEPRECATED
+# Future: Delete BuiltinModels in a future release, it is DEPRECATED
 class BuiltinModels(torch.nn.Module):
     """ BuiltinModels class.
 
@@ -128,15 +128,19 @@ class BuiltinNet(torch.nn.Module):
         return self.energy_shifter(species_energies)
 
     def __getitem__(self, index):
-        ret = torch.nn.Sequential(self.aev_computer,
-                                  self.neural_networks[index],
-                                  self.energy_shifter)
+        ret = torch.nn.Sequential(
+            self.aev_computer,
+            self.neural_networks[index],
+            self.energy_shifter
+        )
 
         def ase(**kwargs):
             from . import ase
-            return ase.Calculator(self.species, self.aev_computer,
+            return ase.Calculator(self.species,
+                                  self.aev_computer,
                                   self.neural_networks[index],
-                                  self.energy_shifter, **kwargs)
+                                  self.energy_shifter,
+                                  **kwargs)
 
         ret.ase = ase
         ret.species_to_tensor = self.consts.species_to_tensor
@@ -161,8 +165,7 @@ class BuiltinNet(torch.nn.Module):
 
 
 class ANI1x(BuiltinNet):
-    """The ANI-1x model as in `ani-1x_8x on
-    GitHub`_ and `Active Learning Paper`_.
+    """The ANI-1x model as in `ani-1x_8x on GitHub`_ and `Active Learning Paper`_.
 
     The ANI-1x model is an ensemble of 8 networks that was trained using
     active learning on the ANI-1x dataset, the target level of theory is
@@ -198,8 +201,7 @@ class ANI1x(BuiltinNet):
 
 
 class ANI1ccx(BuiltinNet):
-    """Factory method to instantiate the ANI-1x model as in `ani-1ccx_8x on
-    GitHub`_ and `Transfer Learning Paper`_.
+    """The ANI-1x model as in `ani-1ccx_8x on GitHub`_ and `Transfer Learning Paper`_.
 
     The ANI-1ccx model is an ensemble of 8 networks that was trained
     on the ANI-1ccx dataset, using transfer learning. The target accuracy

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 """The ANI model zoo that stores public ANI models.
 
-Currently the model zoo has two models: ANI-1x and ANI-1ccx. The corresponding
-classes of these two models are :class:`ANI1x` and :class:`ANI1ccx`. These
-classes share the same API. To use the builtin models, you simply need to
-create an object of its corresponding class. These classes are subclasses of
-:class:`torch.nn.Module`, and could be used directly. Below is an example of
-how to use these models:
+Currently the model zoo has two models: ANI-1x and ANI-1ccx. The classes
+of these two models are :class:`ANI1x` and :class:`ANI1ccx`, 
+these are subclasses of :class:`torch.nn.Module`. 
+To use the models just instantiate them and either
+directly calculate energies or get an ASE calculator. For example:
 
 .. code:: python
-
     model = torchani.models.ANI1x()
     # compute energy using ANI-1x model ensemble
     _, energies = model((species, coordinates))
@@ -23,15 +21,30 @@ how to use these models:
     model0.ase()  # get ASE Calculator using this model
     # convert atom species from string to long tensor
     model0.species_to_tensor('CHHHH')
+
+Note that the class BuiltinModels can be accessed but it is deprecated and 
+shouldn't be used anymore.
+
 """
 
 import torch
+import warnings
+from pkg_resources import resource_filename
 from . import neurochem
+from .aev import AEVComputer
 
-
+# TODO: Delete BuiltinModels in a future release, it is DEPRECATED
 class BuiltinModels(torch.nn.Module):
+    """ BuiltinModels class.
+
+    This class is part of an old API. It is DEPRECATED and may be deleted in a
+    future version. It shouldn't be used.
+    """
 
     def __init__(self, builtin_class):
+        warnings.warn("BuiltinsModels is deprecated and will be deleted in"
+                "the future; use torchani.models.BuiltinNet()",
+                DeprecationWarning)
         super(BuiltinModels, self).__init__()
         self.builtins = builtin_class()
         self.aev_computer = self.builtins.aev_computer
@@ -80,31 +93,147 @@ class BuiltinModels(torch.nn.Module):
             .to(self.aev_computer.ShfR.device)
 
 
-class ANI1x(BuiltinModels):
-    """The ANI-1x model as in `ani-1x_8x on GitHub`_ and
-    `Active Learning Paper`_.
+class BuiltinNet(torch.nn.Module):
+    """ Template for the builtin ANI models.
 
+    Attributes:
+        const_file (:class:`str`): Path to the file with the builtin constants.
+        sae_file (:class:`str`): Path to the file with the Self Atomic Energies.
+        ensemble_prefix (:class:`str`): Prefix of directories.
+
+        ensemble_size (:class:`int`): Number of models in the ensemble.
+        energy_shifter (:class:`torchani.EnergyShifter`): Energy shifter with 
+            builtin Self Atomic Energies.
+        aev_computer (:class:`torchani.AEVComputer`): AEV computer with
+            builtin constants
+        neural_networks (:class:`torchani.Ensemble`): Ensemble of models
+    """
+    def __init__(self, parent_name, const_file_path, sae_file_path, 
+            ensemble_size, ensemble_prefix_path):
+        super(BuiltinNets, self).__init__()
+
+        self.const_file = resource_filename(parent_name,const_file_path)
+        self.sae_file = resource_filename(parent_name,sae_file_path)
+        self.ensemble_prefix = resource_filename(parent_name,ensemble_prefix_path)
+
+        self.ensemble_size = ensemble_size
+        self.consts = neurochem.Constants(self.const_file)
+        self.species = self.consts.species
+        self.aev_computer = AEVComputer(**self.consts)
+        self.energy_shifter = neurochem.load_sae(self.sae_file)
+        self.neural_networks = neurochem.load_model_ensemble(self.species,
+                                                             self.ensemble_prefix,
+                                                             self.ensemble_size)
+
+    def forward(self, species_coordinates):
+        species_aevs = self.aev_computer(species_coordinates)
+        species_energies = self.neural_networks(species_aevs)
+        return self.energy_shifter(species_energies)
+
+    def __getitem__(self, index):
+        ret = torch.nn.Sequential(
+            self.aev_computer,
+            self.neural_networks[index],
+            self.energy_shifter
+        )
+
+        def ase(**kwargs):
+            from . import ase
+            return ase.Calculator(self.species,
+                                  self.aev_computer,
+                                  self.neural_networks[index],
+                                  self.energy_shifter,
+                                  **kwargs)
+
+        ret.ase = ase
+        ret.species_to_tensor = self.consts.species_to_tensor
+        return ret
+
+    def __len__(self):
+        return len(self.neural_networks)
+
+    def ase(self, **kwargs):
+        """Get an ASE Calculator using this model"""
+        from . import ase
+        return ase.Calculator(self.species, self.aev_computer,
+                              self.neural_networks, self.energy_shifter,
+                              **kwargs)
+
+    def species_to_tensor(self, *args, **kwargs):
+        """Convert species from strings to tensor.
+
+        See also :method:`torchani.neurochem.Constant.species_to_tensor`"""
+        return self.consts.species_to_tensor(*args, **kwargs) \
+            .to(self.aev_computer.ShfR.device)
+
+class ANI1x(BuiltinNet):
+    """The ANI-1x model as in `ani-1x_8x on 
+    GitHub`_ and `Active Learning Paper`_. 
+    
+    The ANI-1x model is an ensemble of 8 networks that was trained using 
+    active learning on the ANI-1x dataset, the target level of theory is 
+    wB97X/6-31G(d). It predicts energies on HCNO elements exclusively, it 
+    shouldn't be used with other atom types.
+    
     .. _ani-1x_8x on GitHub:
         https://github.com/isayev/ASE_ANI/tree/master/ani_models/ani-1x_8x
-
+    
     .. _Active Learning Paper:
         https://aip.scitation.org/doi/abs/10.1063/1.5023802
+    Attributes:
+        const_file (:class:`str`): Path to the file with the builtin constants.
+        sae_file (:class:`str`): Path to file with the Self Atomic Energies.
+        ensemble_prefix (:class:`str`): Prefix of directories.
+
+        ensemble_size (:class:`int`): Number of models in the ensemble.
+        energy_shifter (:class:`torchani.EnergyShifter`): Energy shifter with 
+            builtin Self Atomic Energies.
+        aev_computer (:class:`torchani.AEVComputer`): AEV computer with
+            builtin constants
+        neural_networks (:class:`torchani.Ensemble`): Ensemble of models
     """
+    def __init__(self, 
+        parent_name = '.'.join(__name__.split('.')[:-1]),
+        const_file_path = 'resources/ani-1x_8x'\
+            '/rHCNO-5.2R_16-3.5A_a4-8.params',
+        sae_file_path = 'resources/ani-1x_8x/sae_linfit.dat',
+        ensemble_size = 8,
+        ensemble_prefix_path = 'resources/ani-1x_8x/train'):
+        super(ANI1x, self).__init__()
 
-    def __init__(self):
-        super(ANI1x, self).__init__(neurochem.Builtins)
 
-
-class ANI1ccx(BuiltinModels):
-    """The ANI-1x model as in `ani-1ccx_8x on GitHub`_ and
-    `Transfer Learning Paper`_.
-
+class ANI1ccx(BuiltinNet):
+    """Factory method to instantiate the ANI-1x model as in `ani-1ccx_8x on 
+    GitHub`_ and `Transfer Learning Paper`_.
+    
+    The ANI-1ccx model is an ensemble of 8 networks that was trained 
+    on the ANI-1ccx dataset, using transfer learning. The target accuracy
+    is CCSD(T)*/CBS (CCSD(T) using the DPLNO-CCSD(T) method). It predicts 
+    energies on HCNO elements exclusively, it shouldn't be used with other
+    atom types.
+    
     .. _ani-1ccx_8x on GitHub:
         https://github.com/isayev/ASE_ANI/tree/master/ani_models/ani-1ccx_8x
-
+    
     .. _Transfer Learning Paper:
         https://doi.org/10.26434/chemrxiv.6744440.v1
-    """
+    Attributes:
+        const_file (:class:`str`): Path to the file with the builtin constants.
+        sae_file (:class:`str`): Path to file with the Self Atomic Energies.
+        ensemble_prefix (:class:`str`): Prefix of directories.
 
-    def __init__(self):
-        super(ANI1ccx, self).__init__(neurochem.BuiltinsANI1CCX)
+        ensemble_size (:class:`int`): Number of models in the ensemble.
+        energy_shifter (:class:`torchani.EnergyShifter`): Energy shifter with 
+            builtin Self Atomic Energies.
+        aev_computer (:class:`torchani.AEVComputer`): AEV computer with
+            builtin constants
+        neural_networks (:class:`torchani.Ensemble`): Ensemble of models
+    """
+    def __init__(self, 
+        parent_name = '.'.join(__name__.split('.')[:-1]),
+        const_file_path = 'resources/ani-1ccx_8x'\
+            '/rHCNO-5.2R_16-3.5A_a4-8.params',
+        sae_file_path = 'resources/ani-1ccx_8x/sae_linfit.dat',
+        ensemble_size = 8,
+        ensemble_prefix_path = 'resources/ani-1ccx_8x/train'):
+        super(ANI1ccx, self).__init__()

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -15,7 +15,7 @@ directly calculate energies or get an ASE calculator. For example:
     # convert atom species from string to long tensor
     ani1x.species_to_tensor('CHHHH')
 
-    model0 = ani1x.neural_networks[0]  # get the first model in the ensemble
+    model0 = ani1x[0]  # get the first model in the ensemble
     # compute energy using the first model in the ANI-1x model ensemble
     _, energies = model0((species, coordinates))
     model0.ase()  # get ASE Calculator using this model

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -37,8 +37,9 @@ from .aev import AEVComputer
 class BuiltinModels(torch.nn.Module):
     """ BuiltinModels class.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a
-    future version. It shouldn't be used.
+    .. warning::
+        This class is part of an old API. It is DEPRECATED and may be deleted in a
+        future version. It shouldn't be used.
     """
 
     def __init__(self, builtin_class):

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -266,8 +266,9 @@ def load_model_ensemble(species, prefix, count):
 class BuiltinsAbstract(object):
     """Base class for loading ANI neural network from configuration files.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a
-    future version. It shouldn't be used.
+    .. warning::
+        This class is part of an old API. It is DEPRECATED and may be deleted in a
+        future version. It shouldn't be used.
 
     Arguments:
         parent_name (:class:`str`): Base path that other paths are relative to.
@@ -323,8 +324,9 @@ class BuiltinsAbstract(object):
 class Builtins(BuiltinsAbstract):
     """Container for the builtin ANI-1x model.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a
-    future version. It shouldn't be used.
+    .. warning::
+        This class is part of an old API. It is DEPRECATED and may be deleted in a
+        future version. It shouldn't be used.
 
     Attributes:
         const_file (:class:`str`): Path to the builtin constant file.
@@ -362,8 +364,9 @@ class Builtins(BuiltinsAbstract):
 class BuiltinsANI1CCX(BuiltinsAbstract):
     """Container for the builtin ANI-1ccx model.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a
-    future version. It shouldn't be used.
+    .. warning::
+        This class is part of an old API. It is DEPRECATED and may be deleted in a
+        future version. It shouldn't be used.
 
     Attributes:
         const_file (:class:`str`): Path to the builtin constant file.

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -858,5 +858,5 @@ if sys.version_info[0] > 2:
                 lr *= self.lr_decay
 
 
-__all__ = ['Constants', 'load_sae', 'load_model', 'load_model_ensemble', 'Builtins',
-           'Trainer']
+__all__ = ['Constants', 'load_sae', 'load_model', 'load_model_ensemble',
+           'Builtins', 'Trainer']

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -40,19 +40,14 @@ class Constants(collections.abc.Mapping):
                     value = line[1]
                     if name == 'Rcr' or name == 'Rca':
                         setattr(self, name, float(value))
-                    elif name in [
-                            'EtaR', 'ShfR', 'Zeta', 'ShfZ', 'EtaA', 'ShfA'
-                    ]:
-                        value = [
-                            float(x.strip()) for x in value.replace(
-                                '[', '').replace(']', '').split(',')
-                        ]
+                    elif name in ['EtaR', 'ShfR', 'Zeta',
+                                  'ShfZ', 'EtaA', 'ShfA']:
+                        value = [float(x.strip()) for x in value.replace(
+                            '[', '').replace(']', '').split(',')]
                         setattr(self, name, torch.tensor(value))
                     elif name == 'Atyp':
-                        value = [
-                            x.strip() for x in value.replace('[', '').replace(
-                                ']', '').split(',')
-                        ]
+                        value = [x.strip() for x in value.replace('[', '').replace(
+                            ']', '').split(',')]
                         self.species = value
                 except Exception:
                     raise ValueError('unable to parse const file')
@@ -110,7 +105,7 @@ def load_atomic_network(filename):
     and parameters loaded NeuroChem's .nnf, .wparam and .bparam files."""
 
     def decompress_nnf(buffer_):
-        while buffer_[0] != b'=' [0]:
+        while buffer_[0] != b'='[0]:
             buffer_ = buffer_[1:]
         buffer_ = buffer_[2:]
         return bz2.decompress(buffer_)[:-1].decode('ascii').strip()
@@ -151,6 +146,7 @@ def load_atomic_network(filename):
 
         # execute parse tree
         class TreeExec(lark.Transformer):
+
             def identifier(self, v):
                 v = v[0].value
                 return v
@@ -266,7 +262,7 @@ def load_model_ensemble(species, prefix, count):
     return Ensemble(models)
 
 
-# TODO: Delete BuiltinsAbstract in a future release, it is DEPRECATED
+# Future: Delete BuiltinsAbstract in a future release, it is DEPRECATED
 class BuiltinsAbstract(object):
     """Base class for loading ANI neural network from configuration files.
 
@@ -295,10 +291,16 @@ class BuiltinsAbstract(object):
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
 
-    def __init__(self, parent_name, const_file_path, sae_file_path,
-                 ensemble_size, ensemble_prefix_path):
+    def __init__(
+            self,
+            parent_name,
+            const_file_path,
+            sae_file_path,
+            ensemble_size,
+            ensemble_prefix_path):
         self.const_file = pkg_resources.resource_filename(
-            parent_name, const_file_path)
+            parent_name,
+            const_file_path)
         warnings.warn(
             "BuiltinsAbstract is deprecated and will be deleted in"
             "the future; use torchani.models.BuiltinNet()", DeprecationWarning)
@@ -306,17 +308,19 @@ class BuiltinsAbstract(object):
         self.species = self.consts.species
         self.aev_computer = AEVComputer(**self.consts)
         self.sae_file = pkg_resources.resource_filename(
-            parent_name, sae_file_path)
+            parent_name,
+            sae_file_path)
         self.energy_shifter = load_sae(self.sae_file)
         self.ensemble_size = ensemble_size
         self.ensemble_prefix = pkg_resources.resource_filename(
-            parent_name, ensemble_prefix_path)
+            parent_name,
+            ensemble_prefix_path)
         self.models = load_model_ensemble(self.consts.species,
                                           self.ensemble_prefix,
                                           self.ensemble_size)
 
 
-# TODO: Delete Builtins in a future release, it is DEPRECATED
+# Future: Delete Builtins in a future release, it is DEPRECATED
 class Builtins(BuiltinsAbstract):
     """Container for the builtin ANI-1x model.
 
@@ -336,7 +340,6 @@ class Builtins(BuiltinsAbstract):
         ensemble_prefix (:class:`str`): Prefix of directories of models.
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
-
     def __init__(self):
         warnings.warn(
             "Builtins is deprecated and will be deleted in the"
@@ -347,12 +350,16 @@ class Builtins(BuiltinsAbstract):
         sae_file_path = 'resources/ani-1x_8x/sae_linfit.dat'
         ensemble_size = 8
         ensemble_prefix_path = 'resources/ani-1x_8x/train'
-        super(Builtins,
-              self).__init__(parent_name, const_file_path, sae_file_path,
-                             ensemble_size, ensemble_prefix_path)
+        super(Builtins, self).__init__(
+            parent_name,
+            const_file_path,
+            sae_file_path,
+            ensemble_size,
+            ensemble_prefix_path
+        )
 
 
-# TODO: Delete BuiltinsANI1CCX in a future release, it is DEPRECATED
+# Future: Delete BuiltinsANI1CCX in a future release, it is DEPRECATED
 class BuiltinsANI1CCX(BuiltinsAbstract):
     """Container for the builtin ANI-1ccx model.
 
@@ -372,7 +379,6 @@ class BuiltinsANI1CCX(BuiltinsAbstract):
         ensemble_prefix (:class:`str`): Prefix of directories of models.
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
-
     def __init__(self):
         warnings.warn(
             "BuiltinsANICCX is deprecated and will be deleted in the"
@@ -383,9 +389,13 @@ class BuiltinsANI1CCX(BuiltinsAbstract):
         sae_file_path = 'resources/ani-1ccx_8x/sae_linfit.dat'
         ensemble_size = 8
         ensemble_prefix_path = 'resources/ani-1ccx_8x/train'
-        super(BuiltinsANI1CCX,
-              self).__init__(parent_name, const_file_path, sae_file_path,
-                             ensemble_size, ensemble_prefix_path)
+        super(BuiltinsANI1CCX, self).__init__(
+            parent_name,
+            const_file_path,
+            sae_file_path,
+            ensemble_size,
+            ensemble_prefix_path
+        )
 
 
 def hartree2kcal(x):
@@ -408,12 +418,8 @@ if sys.version_info[0] > 2:
                 will be stored in the network directory with this file name.
         """
 
-        def __init__(self,
-                     filename,
-                     device=torch.device('cuda'),
-                     tqdm=False,
-                     tensorboard=None,
-                     aev_caching=False,
+        def __init__(self, filename, device=torch.device('cuda'), tqdm=False,
+                     tensorboard=None, aev_caching=False,
                      checkpoint_name='model.pt'):
             try:
                 import ignite
@@ -508,6 +514,7 @@ if sys.version_info[0] > 2:
             tree = parser.parse(txt)
 
             class TreeExec(lark.Transformer):
+
                 def identifier(self, v):
                     v = v[0].value
                     return v
@@ -652,8 +659,7 @@ if sys.version_info[0] > 2:
                     del layer['activation']
                     if 'l2norm' in layer:
                         if not self.warned:
-                            warnings.warn(
-                                textwrap.dedent("""
+                            warnings.warn(textwrap.dedent("""
                                 Currently TorchANI training with weight decay can not reproduce the training
                                 result of NeuroChem with the same training setup. If you really want to use
                                 weight decay, consider smaller rates and and make sure you do enough validation
@@ -662,16 +668,14 @@ if sys.version_info[0] > 2:
                         if layer['l2norm'] == 1:
                             self.parameters.append({
                                 'params': [module.weight],
-                                'weight_decay':
-                                layer['l2valu'],
+                                'weight_decay': layer['l2valu'],
                             })
                             self.parameters.append({
                                 'params': [module.bias],
                             })
                         else:
                             self.parameters.append({
-                                'params':
-                                module.parameters(),
+                                'params': module.parameters(),
                             })
                         del layer['l2norm']
                         del layer['l2valu']
@@ -684,21 +688,19 @@ if sys.version_info[0] > 2:
                             'unrecognized parameter in layer setup')
                     i = o
                 atomic_nets[atom_type] = torch.nn.Sequential(*modules)
-            self.model = ANIModel(
-                [atomic_nets[s] for s in self.consts.species])
+            self.model = ANIModel([atomic_nets[s]
+                                   for s in self.consts.species])
             if self.aev_caching:
                 self.nnp = self.model
             else:
                 self.nnp = torch.nn.Sequential(self.aev_computer, self.model)
-            self.container = self.imports.Container({
-                'energies': self.nnp
-            }).to(self.device)
+            self.container = self.imports.Container({'energies': self.nnp}).to(self.device)
 
             # losses
             self.mse_loss = self.imports.MSELoss('energies')
             self.exp_loss = self.imports.TransformedLoss(
-                self.imports.MSELoss(
-                    'energies'), lambda x: 0.5 * (torch.exp(2 * x) - 1))
+                self.imports.MSELoss('energies'),
+                lambda x: 0.5 * (torch.exp(2 * x) - 1))
 
             if params:
                 raise ValueError('unrecognized parameter')
@@ -715,11 +717,11 @@ if sys.version_info[0] > 2:
                     'RMSE': self.imports.RMSEMetric('energies'),
                     'MAE': self.imports.MAEMetric('energies'),
                     'MaxAE': self.imports.MaxAEMetric('energies'),
-                })
+                }
+            )
             evaluator.run(dataset)
             metrics = evaluator.state.metrics
-            return hartree2kcal(metrics['RMSE']), hartree2kcal(
-                metrics['MAE']), hartree2kcal(metrics['MaxAE'])
+            return hartree2kcal(metrics['RMSE']), hartree2kcal(metrics['MAE']), hartree2kcal(metrics['MaxAE'])
 
         def load_data(self, training_path, validation_path):
             """Load training and validation dataset from file.
@@ -729,20 +731,15 @@ if sys.version_info[0] > 2:
             """
             if self.aev_caching:
                 self.training_set = self.imports.AEVCacheLoader(training_path)
-                self.validation_set = self.imports.AEVCacheLoader(
-                    validation_path)
+                self.validation_set = self.imports.AEVCacheLoader(validation_path)
             else:
                 self.training_set = self.imports.BatchedANIDataset(
-                    training_path,
-                    self.consts.species_to_tensor,
-                    self.training_batch_size,
-                    device=self.device,
+                    training_path, self.consts.species_to_tensor,
+                    self.training_batch_size, device=self.device,
                     transform=[self.shift_energy.subtract_from_dataset])
                 self.validation_set = self.imports.BatchedANIDataset(
-                    validation_path,
-                    self.consts.species_to_tensor,
-                    self.validation_batch_size,
-                    device=self.device,
+                    validation_path, self.consts.species_to_tensor,
+                    self.validation_batch_size, device=self.device,
                     transform=[self.shift_energy.subtract_from_dataset])
 
         def run(self):
@@ -750,6 +747,7 @@ if sys.version_info[0] > 2:
             start = timeit.default_timer()
 
             def decorate(trainer):
+
                 @trainer.on(self.ignite.engine.Events.STARTED)
                 def initialize(trainer):
                     trainer.state.no_improve_count = 0
@@ -762,14 +760,12 @@ if sys.version_info[0] > 2:
                     self.global_iteration = trainer.state.iteration
 
                 if self.nmax > 0:
-
                     @trainer.on(self.ignite.engine.Events.EPOCH_COMPLETED)
                     def terminate_when_nmax_reaches(trainer):
                         if trainer.state.epoch >= self.nmax:
                             trainer.terminate()
 
                 if self.tqdm is not None:
-
                     @trainer.on(self.ignite.engine.Events.EPOCH_STARTED)
                     def init_tqdm(trainer):
                         trainer.state.tqdm = self.tqdm(
@@ -799,7 +795,6 @@ if sys.version_info[0] > 2:
                         trainer.terminate()
 
                 if self.tensorboard is not None:
-
                     @trainer.on(self.ignite.engine.Events.EPOCH_STARTED)
                     def log_per_epoch(trainer):
                         elapsed = round(timeit.default_timer() - start, 2)
@@ -812,9 +807,8 @@ if sys.version_info[0] > 2:
                                                     trainer.state.rmse, epoch)
                         self.tensorboard.add_scalar('validation_mae_vs_epoch',
                                                     trainer.state.mae, epoch)
-                        self.tensorboard.add_scalar(
-                            'validation_maxae_vs_epoch', trainer.state.maxae,
-                            epoch)
+                        self.tensorboard.add_scalar('validation_maxae_vs_epoch',
+                                                    trainer.state.maxae, epoch)
                         self.tensorboard.add_scalar(
                             'best_validation_rmse_vs_epoch',
                             self.best_validation_rmse, epoch)
@@ -837,8 +831,8 @@ if sys.version_info[0] > 2:
                     def log_loss(trainer):
                         iteration = trainer.state.iteration
                         loss = trainer.state.output
-                        self.tensorboard.add_scalar('loss_vs_iteration', loss,
-                                                    iteration)
+                        self.tensorboard.add_scalar('loss_vs_iteration',
+                                                    loss, iteration)
 
             lr = self.init_lr
 
@@ -865,7 +859,5 @@ if sys.version_info[0] > 2:
                 lr *= self.lr_decay
 
 
-__all__ = [
-    'Constants', 'load_sae', 'load_model', 'load_model_ensemble', 'Builtins',
-    'Trainer'
-]
+__all__ = ['Constants', 'load_sae', 'load_model', 'load_model_ensemble', 'Builtins',
+           'Trainer']

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -46,8 +46,8 @@ class Constants(collections.abc.Mapping):
                             '[', '').replace(']', '').split(',')]
                         setattr(self, name, torch.tensor(value))
                     elif name == 'Atyp':
-                        value = [x.strip() for x in value.replace('[', '').replace(
-                            ']', '').split(',')]
+                        value = [x.strip() for x in value.replace(
+                            '[', '').replace(']', '').split(',')]
                         self.species = value
                 except Exception:
                     raise ValueError('unable to parse const file')
@@ -290,7 +290,6 @@ class BuiltinsAbstract(object):
         ensemble_prefix (:class:`str`): Prefix of directories of models.
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
-
     def __init__(
             self,
             parent_name,

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -261,9 +261,12 @@ def load_model_ensemble(species, prefix, count):
         models.append(load_model(species, network_dir))
     return Ensemble(models)
 
-
+# TODO: Delete BuiltinsAbstract in a future release, it is DEPRECATED
 class BuiltinsAbstract(object):
-    """Base class for loading ANI neural network from configuration files.
+    """Base class for loading ANI neural network from configuration files. 
+
+    This class is part of an old API. It is DEPRECATED and may be deleted in a 
+    future version. It shouldn't be used.
 
     Arguments:
         parent_name (:class:`str`): Base path that other paths are relative to.
@@ -287,15 +290,13 @@ class BuiltinsAbstract(object):
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
     def __init__(
-            self,
-            parent_name,
-            const_file_path,
-            sae_file_path,
-            ensemble_size,
-            ensemble_prefix_path):
+            self,parent_name,const_file_path,sae_file_path,ensemble_size,ensemble_prefix_path):
         self.const_file = pkg_resources.resource_filename(
             parent_name,
             const_file_path)
+        warnings.warn("BuiltinsAbstract is deprecated and will be deleted in"
+                "the future; use torchani.models.BuiltinNet()",
+                DeprecationWarning)
         self.consts = Constants(self.const_file)
         self.species = self.consts.species
         self.aev_computer = AEVComputer(**self.consts)
@@ -311,9 +312,12 @@ class BuiltinsAbstract(object):
                                           self.ensemble_prefix,
                                           self.ensemble_size)
 
-
+# TODO: Delete Builtins in a future release, it is DEPRECATED
 class Builtins(BuiltinsAbstract):
     """Container for the builtin ANI-1x model.
+
+    This class is part of an old API. It is DEPRECATED and may be deleted in a 
+    future version. It shouldn't be used.
 
     Attributes:
         const_file (:class:`str`): Path to the builtin constant file.
@@ -329,6 +333,8 @@ class Builtins(BuiltinsAbstract):
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
     def __init__(self):
+        warnings.warn("Builtins is deprecated and will be deleted in the"
+            "future; use torchani.models.ANI1x()", DeprecationWarning)
         parent_name = '.'.join(__name__.split('.')[:-1])
         const_file_path = 'resources/ani-1x_8x'\
             '/rHCNO-5.2R_16-3.5A_a4-8.params'
@@ -343,9 +349,12 @@ class Builtins(BuiltinsAbstract):
             ensemble_prefix_path
         )
 
-
+# TODO: Delete BuiltinsANI1CCX in a future release, it is DEPRECATED
 class BuiltinsANI1CCX(BuiltinsAbstract):
     """Container for the builtin ANI-1ccx model.
+
+    This class is part of an old API. It is DEPRECATED and may be deleted in a 
+    future version. It shouldn't be used.
 
     Attributes:
         const_file (:class:`str`): Path to the builtin constant file.
@@ -361,6 +370,8 @@ class BuiltinsANI1CCX(BuiltinsAbstract):
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
     def __init__(self):
+        warnings.warn("BuiltinsANICCX is deprecated and will be deleted in the"
+            "future; use torchani.models.ANI1ccx()", DeprecationWarning)
         parent_name = '.'.join(__name__.split('.')[:-1])
         const_file_path = 'resources/ani-1ccx_8x'\
             '/rHCNO-5.2R_16-3.5A_a4-8.params'

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -40,14 +40,19 @@ class Constants(collections.abc.Mapping):
                     value = line[1]
                     if name == 'Rcr' or name == 'Rca':
                         setattr(self, name, float(value))
-                    elif name in ['EtaR', 'ShfR', 'Zeta',
-                                  'ShfZ', 'EtaA', 'ShfA']:
-                        value = [float(x.strip()) for x in value.replace(
-                            '[', '').replace(']', '').split(',')]
+                    elif name in [
+                            'EtaR', 'ShfR', 'Zeta', 'ShfZ', 'EtaA', 'ShfA'
+                    ]:
+                        value = [
+                            float(x.strip()) for x in value.replace(
+                                '[', '').replace(']', '').split(',')
+                        ]
                         setattr(self, name, torch.tensor(value))
                     elif name == 'Atyp':
-                        value = [x.strip() for x in value.replace(
-                            '[', '').replace(']', '').split(',')]
+                        value = [
+                            x.strip() for x in value.replace('[', '').replace(
+                                ']', '').split(',')
+                        ]
                         self.species = value
                 except Exception:
                     raise ValueError('unable to parse const file')
@@ -105,7 +110,7 @@ def load_atomic_network(filename):
     and parameters loaded NeuroChem's .nnf, .wparam and .bparam files."""
 
     def decompress_nnf(buffer_):
-        while buffer_[0] != b'='[0]:
+        while buffer_[0] != b'=' [0]:
             buffer_ = buffer_[1:]
         buffer_ = buffer_[2:]
         return bz2.decompress(buffer_)[:-1].decode('ascii').strip()
@@ -146,7 +151,6 @@ def load_atomic_network(filename):
 
         # execute parse tree
         class TreeExec(lark.Transformer):
-
             def identifier(self, v):
                 v = v[0].value
                 return v
@@ -261,11 +265,12 @@ def load_model_ensemble(species, prefix, count):
         models.append(load_model(species, network_dir))
     return Ensemble(models)
 
+
 # TODO: Delete BuiltinsAbstract in a future release, it is DEPRECATED
 class BuiltinsAbstract(object):
-    """Base class for loading ANI neural network from configuration files. 
+    """Base class for loading ANI neural network from configuration files.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a 
+    This class is part of an old API. It is DEPRECATED and may be deleted in a
     future version. It shouldn't be used.
 
     Arguments:
@@ -289,34 +294,33 @@ class BuiltinsAbstract(object):
         ensemble_prefix (:class:`str`): Prefix of directories of models.
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
-    def __init__(
-            self,parent_name,const_file_path,sae_file_path,ensemble_size,ensemble_prefix_path):
+
+    def __init__(self, parent_name, const_file_path, sae_file_path,
+                 ensemble_size, ensemble_prefix_path):
         self.const_file = pkg_resources.resource_filename(
-            parent_name,
-            const_file_path)
-        warnings.warn("BuiltinsAbstract is deprecated and will be deleted in"
-                "the future; use torchani.models.BuiltinNet()",
-                DeprecationWarning)
+            parent_name, const_file_path)
+        warnings.warn(
+            "BuiltinsAbstract is deprecated and will be deleted in"
+            "the future; use torchani.models.BuiltinNet()", DeprecationWarning)
         self.consts = Constants(self.const_file)
         self.species = self.consts.species
         self.aev_computer = AEVComputer(**self.consts)
         self.sae_file = pkg_resources.resource_filename(
-            parent_name,
-            sae_file_path)
+            parent_name, sae_file_path)
         self.energy_shifter = load_sae(self.sae_file)
         self.ensemble_size = ensemble_size
         self.ensemble_prefix = pkg_resources.resource_filename(
-            parent_name,
-            ensemble_prefix_path)
+            parent_name, ensemble_prefix_path)
         self.models = load_model_ensemble(self.consts.species,
                                           self.ensemble_prefix,
                                           self.ensemble_size)
+
 
 # TODO: Delete Builtins in a future release, it is DEPRECATED
 class Builtins(BuiltinsAbstract):
     """Container for the builtin ANI-1x model.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a 
+    This class is part of an old API. It is DEPRECATED and may be deleted in a
     future version. It shouldn't be used.
 
     Attributes:
@@ -332,8 +336,10 @@ class Builtins(BuiltinsAbstract):
         ensemble_prefix (:class:`str`): Prefix of directories of models.
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
+
     def __init__(self):
-        warnings.warn("Builtins is deprecated and will be deleted in the"
+        warnings.warn(
+            "Builtins is deprecated and will be deleted in the"
             "future; use torchani.models.ANI1x()", DeprecationWarning)
         parent_name = '.'.join(__name__.split('.')[:-1])
         const_file_path = 'resources/ani-1x_8x'\
@@ -341,19 +347,16 @@ class Builtins(BuiltinsAbstract):
         sae_file_path = 'resources/ani-1x_8x/sae_linfit.dat'
         ensemble_size = 8
         ensemble_prefix_path = 'resources/ani-1x_8x/train'
-        super(Builtins, self).__init__(
-            parent_name,
-            const_file_path,
-            sae_file_path,
-            ensemble_size,
-            ensemble_prefix_path
-        )
+        super(Builtins,
+              self).__init__(parent_name, const_file_path, sae_file_path,
+                             ensemble_size, ensemble_prefix_path)
+
 
 # TODO: Delete BuiltinsANI1CCX in a future release, it is DEPRECATED
 class BuiltinsANI1CCX(BuiltinsAbstract):
     """Container for the builtin ANI-1ccx model.
 
-    This class is part of an old API. It is DEPRECATED and may be deleted in a 
+    This class is part of an old API. It is DEPRECATED and may be deleted in a
     future version. It shouldn't be used.
 
     Attributes:
@@ -369,8 +372,10 @@ class BuiltinsANI1CCX(BuiltinsAbstract):
         ensemble_prefix (:class:`str`): Prefix of directories of models.
         models (:class:`torchani.Ensemble`): Ensemble of models.
     """
+
     def __init__(self):
-        warnings.warn("BuiltinsANICCX is deprecated and will be deleted in the"
+        warnings.warn(
+            "BuiltinsANICCX is deprecated and will be deleted in the"
             "future; use torchani.models.ANI1ccx()", DeprecationWarning)
         parent_name = '.'.join(__name__.split('.')[:-1])
         const_file_path = 'resources/ani-1ccx_8x'\
@@ -378,13 +383,9 @@ class BuiltinsANI1CCX(BuiltinsAbstract):
         sae_file_path = 'resources/ani-1ccx_8x/sae_linfit.dat'
         ensemble_size = 8
         ensemble_prefix_path = 'resources/ani-1ccx_8x/train'
-        super(BuiltinsANI1CCX, self).__init__(
-            parent_name,
-            const_file_path,
-            sae_file_path,
-            ensemble_size,
-            ensemble_prefix_path
-        )
+        super(BuiltinsANI1CCX,
+              self).__init__(parent_name, const_file_path, sae_file_path,
+                             ensemble_size, ensemble_prefix_path)
 
 
 def hartree2kcal(x):
@@ -407,8 +408,12 @@ if sys.version_info[0] > 2:
                 will be stored in the network directory with this file name.
         """
 
-        def __init__(self, filename, device=torch.device('cuda'), tqdm=False,
-                     tensorboard=None, aev_caching=False,
+        def __init__(self,
+                     filename,
+                     device=torch.device('cuda'),
+                     tqdm=False,
+                     tensorboard=None,
+                     aev_caching=False,
                      checkpoint_name='model.pt'):
             try:
                 import ignite
@@ -503,7 +508,6 @@ if sys.version_info[0] > 2:
             tree = parser.parse(txt)
 
             class TreeExec(lark.Transformer):
-
                 def identifier(self, v):
                     v = v[0].value
                     return v
@@ -648,7 +652,8 @@ if sys.version_info[0] > 2:
                     del layer['activation']
                     if 'l2norm' in layer:
                         if not self.warned:
-                            warnings.warn(textwrap.dedent("""
+                            warnings.warn(
+                                textwrap.dedent("""
                                 Currently TorchANI training with weight decay can not reproduce the training
                                 result of NeuroChem with the same training setup. If you really want to use
                                 weight decay, consider smaller rates and and make sure you do enough validation
@@ -657,14 +662,16 @@ if sys.version_info[0] > 2:
                         if layer['l2norm'] == 1:
                             self.parameters.append({
                                 'params': [module.weight],
-                                'weight_decay': layer['l2valu'],
+                                'weight_decay':
+                                layer['l2valu'],
                             })
                             self.parameters.append({
                                 'params': [module.bias],
                             })
                         else:
                             self.parameters.append({
-                                'params': module.parameters(),
+                                'params':
+                                module.parameters(),
                             })
                         del layer['l2norm']
                         del layer['l2valu']
@@ -677,19 +684,21 @@ if sys.version_info[0] > 2:
                             'unrecognized parameter in layer setup')
                     i = o
                 atomic_nets[atom_type] = torch.nn.Sequential(*modules)
-            self.model = ANIModel([atomic_nets[s]
-                                   for s in self.consts.species])
+            self.model = ANIModel(
+                [atomic_nets[s] for s in self.consts.species])
             if self.aev_caching:
                 self.nnp = self.model
             else:
                 self.nnp = torch.nn.Sequential(self.aev_computer, self.model)
-            self.container = self.imports.Container({'energies': self.nnp}).to(self.device)
+            self.container = self.imports.Container({
+                'energies': self.nnp
+            }).to(self.device)
 
             # losses
             self.mse_loss = self.imports.MSELoss('energies')
             self.exp_loss = self.imports.TransformedLoss(
-                self.imports.MSELoss('energies'),
-                lambda x: 0.5 * (torch.exp(2 * x) - 1))
+                self.imports.MSELoss(
+                    'energies'), lambda x: 0.5 * (torch.exp(2 * x) - 1))
 
             if params:
                 raise ValueError('unrecognized parameter')
@@ -706,11 +715,11 @@ if sys.version_info[0] > 2:
                     'RMSE': self.imports.RMSEMetric('energies'),
                     'MAE': self.imports.MAEMetric('energies'),
                     'MaxAE': self.imports.MaxAEMetric('energies'),
-                }
-            )
+                })
             evaluator.run(dataset)
             metrics = evaluator.state.metrics
-            return hartree2kcal(metrics['RMSE']), hartree2kcal(metrics['MAE']), hartree2kcal(metrics['MaxAE'])
+            return hartree2kcal(metrics['RMSE']), hartree2kcal(
+                metrics['MAE']), hartree2kcal(metrics['MaxAE'])
 
         def load_data(self, training_path, validation_path):
             """Load training and validation dataset from file.
@@ -720,15 +729,20 @@ if sys.version_info[0] > 2:
             """
             if self.aev_caching:
                 self.training_set = self.imports.AEVCacheLoader(training_path)
-                self.validation_set = self.imports.AEVCacheLoader(validation_path)
+                self.validation_set = self.imports.AEVCacheLoader(
+                    validation_path)
             else:
                 self.training_set = self.imports.BatchedANIDataset(
-                    training_path, self.consts.species_to_tensor,
-                    self.training_batch_size, device=self.device,
+                    training_path,
+                    self.consts.species_to_tensor,
+                    self.training_batch_size,
+                    device=self.device,
                     transform=[self.shift_energy.subtract_from_dataset])
                 self.validation_set = self.imports.BatchedANIDataset(
-                    validation_path, self.consts.species_to_tensor,
-                    self.validation_batch_size, device=self.device,
+                    validation_path,
+                    self.consts.species_to_tensor,
+                    self.validation_batch_size,
+                    device=self.device,
                     transform=[self.shift_energy.subtract_from_dataset])
 
         def run(self):
@@ -736,7 +750,6 @@ if sys.version_info[0] > 2:
             start = timeit.default_timer()
 
             def decorate(trainer):
-
                 @trainer.on(self.ignite.engine.Events.STARTED)
                 def initialize(trainer):
                     trainer.state.no_improve_count = 0
@@ -749,12 +762,14 @@ if sys.version_info[0] > 2:
                     self.global_iteration = trainer.state.iteration
 
                 if self.nmax > 0:
+
                     @trainer.on(self.ignite.engine.Events.EPOCH_COMPLETED)
                     def terminate_when_nmax_reaches(trainer):
                         if trainer.state.epoch >= self.nmax:
                             trainer.terminate()
 
                 if self.tqdm is not None:
+
                     @trainer.on(self.ignite.engine.Events.EPOCH_STARTED)
                     def init_tqdm(trainer):
                         trainer.state.tqdm = self.tqdm(
@@ -784,6 +799,7 @@ if sys.version_info[0] > 2:
                         trainer.terminate()
 
                 if self.tensorboard is not None:
+
                     @trainer.on(self.ignite.engine.Events.EPOCH_STARTED)
                     def log_per_epoch(trainer):
                         elapsed = round(timeit.default_timer() - start, 2)
@@ -796,8 +812,9 @@ if sys.version_info[0] > 2:
                                                     trainer.state.rmse, epoch)
                         self.tensorboard.add_scalar('validation_mae_vs_epoch',
                                                     trainer.state.mae, epoch)
-                        self.tensorboard.add_scalar('validation_maxae_vs_epoch',
-                                                    trainer.state.maxae, epoch)
+                        self.tensorboard.add_scalar(
+                            'validation_maxae_vs_epoch', trainer.state.maxae,
+                            epoch)
                         self.tensorboard.add_scalar(
                             'best_validation_rmse_vs_epoch',
                             self.best_validation_rmse, epoch)
@@ -820,8 +837,8 @@ if sys.version_info[0] > 2:
                     def log_loss(trainer):
                         iteration = trainer.state.iteration
                         loss = trainer.state.output
-                        self.tensorboard.add_scalar('loss_vs_iteration',
-                                                    loss, iteration)
+                        self.tensorboard.add_scalar('loss_vs_iteration', loss,
+                                                    iteration)
 
             lr = self.init_lr
 
@@ -848,5 +865,7 @@ if sys.version_info[0] > 2:
                 lr *= self.lr_decay
 
 
-__all__ = ['Constants', 'load_sae', 'load_model', 'load_model_ensemble',
-           'Builtins', 'Trainer']
+__all__ = [
+    'Constants', 'load_sae', 'load_model', 'load_model_ensemble', 'Builtins',
+    'Trainer'
+]


### PR DESCRIPTION
## Reason for this PR

After speaking with Xiang today he told me that the Builtins and BuiltinsANI1CCX API was an old API that was put inside the new ANI1x and ANI1ccx API for convenience. 

This old API was confusing, since it was carried inside the ANI1x and ANI1ccx models and then the attributes of the old API were passed onto the models, it made the code hard to understand and there wasn't any reason behind it. There were 4 classes doing essentially redundant stuff.

Also, the names of the old API didn't make much sense anymore. For example, 
it wasn't clear that all the tests were using ANI1x. For maintainability reasons I thought it
would be a good idea to **get rid of all this baggage and make things simpler.** 

## I reformatted the API in the following way:

The old classes BuiltinsAbstract, Builtins, BuiltinsANI1ccx and BuiltinModels are all DEPRECATED
I added TODO: remove them in a future version and DeprecationWarning to all of them.

There is just one class now, BuiltinNet, which is basically a new version of BuiltinModels that has all of the necessary functionality and doesn't need other objects to pass on attributes to it when it initializes.

If you were using Builtins OR BuiltinModels for anything you can do the exact same thing with BuiltinNet.

The only difference is that it doesn't have a .models attribute, like Builtins, instead it has a neural_networks attribute, like BuiltinModels

## Possible issues

All the unittests pass, the energies seem OK, and everything works **except gradcheck as usual**
I am kind of shitty with formatting, sorry for changing so much formatting, I would undo that but I don't really know how to =)

## Please don't be intimidated by the the fact that the PR is a bit long, it is a good idea to do this right now for sure, otherwise in the future the code is going to become very messy.
