### PR TITLE
Support 0 molecule subsets when loading dataset

### DIFF
--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -50,8 +50,8 @@ def pad_atomic_properties(atomic_properties, padding_values=defaultdict(lambda: 
     for p in atomic_properties:
         num_molecules = 1
         for v in p.values():
+            assert num_molecules in {1, v.shape[0]}, 'Number of molecules in different atomic properties mismatch'
             if v.shape[0] != 1:
-                assert num_molecules in {1, v.shape[0]}, 'Number of molecules in different atomic properties mismatch'
                 num_molecules = v.shape[0]
         for k, v in p.items():
             shape = list(v.shape)
@@ -59,10 +59,9 @@ def pad_atomic_properties(atomic_properties, padding_values=defaultdict(lambda: 
             shape[1] = padatoms
             padding = v.new_full(shape, padding_values[k])
             v = torch.cat([v, padding], dim=1)
-            if v.shape[0] < num_molecules and v.shape[0] == 1:
-                shape = list(v.shape)
-                shape[0] = num_molecules
-                v = v.expand(*shape)
+            shape = list(v.shape)
+            shape[0] = num_molecules
+            v = v.expand(*shape)
             padded[k].append(v)
     return {k: torch.cat(v) for k, v in padded.items()}
 

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -48,14 +48,17 @@ def pad_atomic_properties(atomic_properties, padding_values=defaultdict(lambda: 
     max_atoms = max(x[anykey].shape[1] for x in atomic_properties)
     padded = {k: [] for k in keys}
     for p in atomic_properties:
-        num_molecules = max(v.shape[0] for v in p.values())
+        num_molecules = 1
+        for v in p.values():
+            if v.shape[0] != 1:
+                assert num_molecules in {1, v.shape[0]}, 'Number of molecules in different atomic properties mismatch'
         for k, v in p.items():
             shape = list(v.shape)
             padatoms = max_atoms - shape[1]
             shape[1] = padatoms
             padding = v.new_full(shape, padding_values[k])
             v = torch.cat([v, padding], dim=1)
-            if v.shape[0] < num_molecules:
+            if v.shape[0] < num_molecules and v.shape[0] == 1:
                 shape = list(v.shape)
                 shape[0] = num_molecules
                 v = v.expand(*shape)

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -52,6 +52,7 @@ def pad_atomic_properties(atomic_properties, padding_values=defaultdict(lambda: 
         for v in p.values():
             if v.shape[0] != 1:
                 assert num_molecules in {1, v.shape[0]}, 'Number of molecules in different atomic properties mismatch'
+                num_molecules = v.shape[0]
         for k, v in p.items():
             shape = list(v.shape)
             padatoms = max_atoms - shape[1]


### PR DESCRIPTION
@farhadrgh, the dataset you dropped me when iterating we get something like:
`{'species': tensor<(1, ...)>, 'coordinates': tensor<(0, ...)>}`, this is an empty subset containing 0 conformations but with atom types well defined...

Originally TorchANI was assuming the number of conformations >= 1 and fails to load this dataset
This PR make TorchANI able to handle this case