### PR TITLE
ASE dropped python2 support

### DIFF
--- a/azure/install_dependencies.sh
+++ b/azure/install_dependencies.sh
@@ -2,4 +2,5 @@
 
 python -m pip install --upgrade pip
 pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-pip install tqdm ase pyyaml future
+pip install tqdm pyyaml future
+pip install 'ase<=3.17'

--- a/azure/install_dependencies_python2.sh
+++ b/azure/install_dependencies_python2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python -m pip install --upgrade pip
+pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+pip install tqdm ase==3.17.0￼ pyyaml future

--- a/azure/install_dependencies_python2.sh
+++ b/azure/install_dependencies_python2.sh
@@ -3,4 +3,4 @@
 python -m pip install --upgrade pip
 pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 pip install tqdm pyyaml future
-pip2 install ase<=3.17.0￼
+pip2 install 'ase<=3.17'

--- a/azure/install_dependencies_python2.sh
+++ b/azure/install_dependencies_python2.sh
@@ -2,4 +2,4 @@
 
 python -m pip install --upgrade pip
 pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-pip install tqdm ase<=3.17.0￼ pyyaml future
+pip install tqdm ase==3.16.2￼ pyyaml future

--- a/azure/install_dependencies_python2.sh
+++ b/azure/install_dependencies_python2.sh
@@ -2,4 +2,4 @@
 
 python -m pip install --upgrade pip
 pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-pip install tqdm ase==3.17.0￼ pyyaml future
+pip install tqdm ase<=3.17.0￼ pyyaml future

--- a/azure/install_dependencies_python2.sh
+++ b/azure/install_dependencies_python2.sh
@@ -2,4 +2,5 @@
 
 python -m pip install --upgrade pip
 pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-pip install tqdm ase==3.16.2￼ pyyaml future
+pip install tqdm pyyaml future
+pip2 install ase<=3.17.0￼

--- a/azure/python2.yml
+++ b/azure/python2.yml
@@ -19,7 +19,7 @@ steps:
   inputs:
     versionSpec: '$(python.version)'
 
-- script: 'azure/install_dependencies.sh && pip install .'
+- script: 'azure/install_dependencies_python2.sh && pip install .'
   displayName: 'Install dependencies'
 
 - script: 'python2 examples/energy_force.py'


### PR DESCRIPTION
The [last version](https://pypi.org/project/ase/3.17.0/) that has python2 support will be installed for python2 tests.