### PR TITLE
Small doc fixes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -56,7 +56,6 @@ NeuroChem
 .. autofunction:: torchani.neurochem.load_atomic_network
 .. autofunction:: torchani.neurochem.load_model
 .. autofunction:: torchani.neurochem.load_model_ensemble
-.. autoclass:: torchani.neurochem.Builtins
 .. autoclass:: torchani.neurochem.Trainer
     :members:
 .. automodule:: torchani.neurochem.trainer

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,8 @@ pygments_style = 'sphinx'
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 htmlhelp_basename = 'TorchANIdoc'
+# Temporary fix for bug in HTML5 support in the RTD theme
+html4_writer=True
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 htmlhelp_basename = 'TorchANIdoc'
 # Temporary fix for bug in HTML5 support in the RTD theme
-html4_writer=True
+html4_writer = True
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -7,7 +7,8 @@ these are subclasses of :class:`torch.nn.Module`.
 To use the models just instantiate them and either
 directly calculate energies or get an ASE calculator. For example:
 
-.. code:: python
+.. code-block:: python
+
     ani1x = torchani.models.ANI1x()
     # compute energy using ANI-1x model ensemble
     _, energies = ani1x((species, coordinates))


### PR DESCRIPTION
## Very small documentation PR

The RTD theme has a bug with HTML5, right now the documentation is not being rendered properly if html4_writer is not enabeled, compare these:

This is the correct render with HTML5
![html5](https://user-images.githubusercontent.com/34223426/62237542-29903780-b39f-11e9-8956-0c798c4dd2ac.png)

This is the current render without HTML5
![no_html5](https://user-images.githubusercontent.com/34223426/62237596-3e6ccb00-b39f-11e9-8cf5-871c2aebfc2c.png)

1) I enabeled the html4 writer
2) I fixed a docstring in the modules.py 
3) I removed Builtins from api.rst since the class no longer exists