### PR TITLE
Remove all large files and stop using git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,0 @@
-*.h5 filter=lfs diff=lfs merge=lfs -text
-tests/test_data/ANI1_subset/* filter=lfs diff=lfs merge=lfs -text
-tests/test_data/NIST/* filter=lfs diff=lfs merge=lfs -text
-tests/test_data/NeuroChemOptimized/* filter=lfs diff=lfs merge=lfs -text
-tests/test_data/benzene-md/* filter=lfs diff=lfs merge=lfs -text
-tests/test_data/tripeptide-md/* filter=lfs diff=lfs merge=lfs -text
-tools/generate-unit-test-expect/nist-dataset/result.json filter=lfs diff=lfs merge=lfs -text
-

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist
 # No vim swap files
 *.swp
 *.swo
+/download

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ dist
 *.swp
 *.swo
 /download
+/download.tar.xz

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ See also [PyTorch's official site](https://pytorch.org/get-started/locally/) for
 
 Please install nightly PyTorch through `pip install` instead of `conda install`. If your PyTorch is installed through `conda install`, then `pip` would mistakenly recognize the package name as `torch` instead of `torch-nightly`, which would cause dependency issue when installing TorchANI.
 
+To run the tests and examples, you must manually download a data package
+
+```bash
+./download.sh
+```
+
 # Paper
 
 The original ANI-1 paper is:
@@ -72,6 +78,8 @@ install dependencies:
 pip install sphinx sphinx-gallery pillow matplotlib sphinx_rtd_theme
 ```
 
+To manually run unit tests, do `python setup.py test`
+
 # Note to TorchANI developers
 
 Never commit to the master branch directly. If you need to change something, create a new branch, submit a PR on GitHub.
@@ -79,5 +87,3 @@ Never commit to the master branch directly. If you need to change something, cre
 You must pass all the tests on GitHub before your PR can be merged.
 
 Code review is required before merging pull request.
-
-To manually run unit tests, do `python setup.py test`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ install dependencies:
 pip install sphinx sphinx-gallery pillow matplotlib sphinx_rtd_theme
 ```
 
-To manually run unit tests, do `python setup.py test`
+To manually run unit tests, do `python setup.py nosetests`
 
 # Note to TorchANI developers
 

--- a/azure/deploy-docs.yml
+++ b/azure/deploy-docs.yml
@@ -26,6 +26,9 @@ steps:
 - script: 'azure/install_dependencies.sh && pip install h5py pytorch-ignite-nightly tb-nightly sphinx sphinx_rtd_theme matplotlib pillow sphinx-gallery && pip install .'
   displayName: 'Install dependencies'
 
+- script: './download.sh'
+  displayName: 'Download data files'
+
 - script: 'sphinx-build docs build'
   displayName: Build documents
 

--- a/azure/deploy-pypi.yml
+++ b/azure/deploy-pypi.yml
@@ -26,6 +26,9 @@ steps:
 - script: 'azure/install_dependencies.sh && pip install nose coverage twine wheel'
   displayName: 'Install dependencies'
 
+- script: './download.sh'
+  displayName: 'Download data files'
+
 - script: 'python setup.py nosetests'
   displayName: Unit tests
 

--- a/azure/docs.yml
+++ b/azure/docs.yml
@@ -21,5 +21,8 @@ steps:
 - script: 'azure/install_dependencies.sh && pip install h5py pytorch-ignite-nightly tb-nightly sphinx sphinx_rtd_theme matplotlib pillow sphinx-gallery && pip install .'
   displayName: 'Install dependencies'
 
+- script: './download.sh'
+  displayName: 'Download data files'
+
 - script: 'sphinx-build docs build'
   displayName: Documents

--- a/azure/runnable_submodules.yml
+++ b/azure/runnable_submodules.yml
@@ -21,14 +21,17 @@ steps:
 - script: 'azure/install_dependencies.sh && pip install h5py .'
   displayName: 'Install dependencies'
 
-- script: 'python -m torchani.data.cache_aev tmp dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 256'
+- script: './download.sh'
+  displayName: 'Download data files'
+
+- script: 'python -m torchani.data.cache_aev tmp download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 256'
   displayName: Cache AEV
 
 - script: 'pip install pytorch-ignite-nightly'
   displayName: 'Install more dependencies'
 
-- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.ipt  dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.ipt  download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: NeuroChem Trainer
 
-- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.yaml  dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.yaml  download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: NeuroChem Trainer YAML config

--- a/azure/runnable_submodules.yml
+++ b/azure/runnable_submodules.yml
@@ -24,14 +24,14 @@ steps:
 - script: './download.sh'
   displayName: 'Download data files'
 
-- script: 'python -m torchani.data.cache_aev tmp download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 256'
+- script: 'python -m torchani.data.cache_aev tmp dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 256'
   displayName: Cache AEV
 
 - script: 'pip install pytorch-ignite-nightly'
   displayName: 'Install more dependencies'
 
-- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.ipt  download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.ipt  dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: NeuroChem Trainer
 
-- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.yaml  download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python -m torchani.neurochem.trainer --tqdm tests/test_data/inputtrain.yaml  dataset/ani1-up_to_gdb4/ani_gdb_s01.h5 dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: NeuroChem Trainer YAML config

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -24,6 +24,9 @@ steps:
 - script: 'azure/install_dependencies.sh && pip install nose coverage codecov'
   displayName: 'Install dependencies'
 
+- script: './download.sh'
+  displayName: 'Download data files'
+
 - script: 'python setup.py nosetests'
   displayName: Unit tests
 

--- a/azure/tools.yml
+++ b/azure/tools.yml
@@ -28,20 +28,20 @@ steps:
 - script: './download.sh'
   displayName: 'Download data files'
 
-- script: 'python tools/inference-benchmark.py --tqdm ./dataset/xyz_files/CH4-5.xyz'
+- script: 'python tools/inference-benchmark.py --tqdm dataset/xyz_files/CH4-5.xyz'
   displayName: Inference Benchmark
 
 - script: 'pip install h5py'
   displayName: 'Install more dependencies'
 
-- script: 'python tools/comp6.py ./dataset/COMP6/COMP6v1/s66x8'
+- script: 'python tools/comp6.py dataset/COMP6/COMP6v1/s66x8'
   displayName: COMP6 Benchmark
 
 - script: 'pip install pytorch-ignite-nightly'
   displayName: 'Install more dependencies'
 
-- script: 'python tools/training-benchmark.py ./dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python tools/training-benchmark.py download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: Training Benchmark
 
-- script: 'python tools/neurochem-test.py ./dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python tools/neurochem-test.py download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: NeuroChem Test

--- a/azure/tools.yml
+++ b/azure/tools.yml
@@ -25,6 +25,9 @@ steps:
 - script: 'azure/install_dependencies.sh && pip install .'
   displayName: 'Install dependencies'
 
+- script: './download.sh'
+  displayName: 'Download data files'
+
 - script: 'python tools/inference-benchmark.py --tqdm ./dataset/xyz_files/CH4-5.xyz'
   displayName: Inference Benchmark
 

--- a/azure/tools.yml
+++ b/azure/tools.yml
@@ -40,8 +40,8 @@ steps:
 - script: 'pip install pytorch-ignite-nightly'
   displayName: 'Install more dependencies'
 
-- script: 'python tools/training-benchmark.py download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python tools/training-benchmark.py /dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: Training Benchmark
 
-- script: 'python tools/neurochem-test.py download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python tools/neurochem-test.py dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: NeuroChem Test

--- a/azure/tools.yml
+++ b/azure/tools.yml
@@ -40,7 +40,7 @@ steps:
 - script: 'pip install pytorch-ignite-nightly'
   displayName: 'Install more dependencies'
 
-- script: 'python tools/training-benchmark.py /dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
+- script: 'python tools/training-benchmark.py dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'
   displayName: Training Benchmark
 
 - script: 'python tools/neurochem-test.py dataset/ani1-up_to_gdb4/ani_gdb_s01.h5'

--- a/dataset/ani-1x
+++ b/dataset/ani-1x
@@ -1,0 +1,1 @@
+../download/dataset/ani-1x/

--- a/dataset/ani-1x/sample.h5
+++ b/dataset/ani-1x/sample.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5be3dfae53325319d6771005e82c3dc7c0114b5dff4e870162a0240db6681583
-size 2140464

--- a/dataset/ani1-up_to_gdb4
+++ b/dataset/ani1-up_to_gdb4
@@ -1,0 +1,1 @@
+../download/dataset/ani1-up_to_gdb4/

--- a/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5
+++ b/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccea4d34bf4d281b857c67864c54ed1883bbae7b394d87ff43367564d438b2e6
-size 634677

--- a/dataset/ani1-up_to_gdb4/ani_gdb_s02.h5
+++ b/dataset/ani1-up_to_gdb4/ani_gdb_s02.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac44c2ee90c9c1f1b0aadb2b97685fcdc0571e242ba97dfdfe1211cfe6e64084
-size 3647595

--- a/dataset/ani1-up_to_gdb4/ani_gdb_s03.h5
+++ b/dataset/ani1-up_to_gdb4/ani_gdb_s03.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25afface447ea2357b40eb3349d9c561c428095a047ec6e0db8ead572ac47e7d
-size 14400349

--- a/dataset/ani1-up_to_gdb4/ani_gdb_s04.h5
+++ b/dataset/ani1-up_to_gdb4/ani_gdb_s04.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c35351f105c7b67178df6181fee7e340237594423039811a47bd8d3c13748b02
-size 77235594

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+wget http://atl.ipv6.ai/download.tar.xz
+tar xvf download.tar.xz

--- a/examples/cache_aev.py
+++ b/examples/cache_aev.py
@@ -26,8 +26,8 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-training_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
-validation_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
+training_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
+validation_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
 
 # checkpoint file to save model when validation RMSE improves
 model_checkpoint = 'model.pt'

--- a/examples/cache_aev.py
+++ b/examples/cache_aev.py
@@ -26,8 +26,8 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-training_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
-validation_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
+training_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
+validation_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
 
 # checkpoint file to save model when validation RMSE improves
 model_checkpoint = 'model.pt'

--- a/examples/neurochem_trainer.py
+++ b/examples/neurochem_trainer.py
@@ -32,8 +32,8 @@ try:
 except NameError:
     path = os.getcwd()
 cfg_path = os.path.join(path, '../tests/test_data/inputtrain.ipt')
-training_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
-validation_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
+training_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
+validation_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
 
 ###############################################################################
 # We also need to set the device to run the training:

--- a/examples/neurochem_trainer.py
+++ b/examples/neurochem_trainer.py
@@ -32,8 +32,8 @@ try:
 except NameError:
     path = os.getcwd()
 cfg_path = os.path.join(path, '../tests/test_data/inputtrain.ipt')
-training_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
-validation_path = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
+training_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
+validation_path = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')  # noqa: E501
 
 ###############################################################################
 # We also need to set the device to run the training:

--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -77,7 +77,7 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-dspath = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
+dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 
 batch_size = 2560
 

--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -77,7 +77,7 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
+dspath = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 
 batch_size = 2560
 

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -42,7 +42,7 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-dspath = os.path.join(path, '../download/dataset/ani-1x/sample.h5')
+dspath = os.path.join(path, '../dataset/ani-1x/sample.h5')
 
 batch_size = 2560
 

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -42,7 +42,7 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-dspath = os.path.join(path, '../dataset/ani-1x/sample.h5')
+dspath = os.path.join(path, '../download/dataset/ani-1x/sample.h5')
 
 batch_size = 2560
 

--- a/examples/nnp_training_ignite.py
+++ b/examples/nnp_training_ignite.py
@@ -36,7 +36,7 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
+dspath = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 
 # checkpoint file to save model when validation RMSE improves
 model_checkpoint = 'model.pt'

--- a/examples/nnp_training_ignite.py
+++ b/examples/nnp_training_ignite.py
@@ -36,7 +36,7 @@ try:
     path = os.path.dirname(os.path.realpath(__file__))
 except NameError:
     path = os.getcwd()
-dspath = os.path.join(path, '../download/dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
+dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 
 # checkpoint file to save model when validation RMSE improves
 model_checkpoint = 'model.pt'

--- a/tests/test_data/ANI1_subset
+++ b/tests/test_data/ANI1_subset
@@ -1,0 +1,1 @@
+../../download/test_data/ANI1_subset/

--- a/tests/test_data/ANI1_subset/0
+++ b/tests/test_data/ANI1_subset/0
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5b485e0bb1f97c0a33fb3062617c992deac4a16ac38303357ffdde05af14652
-size 78939

--- a/tests/test_data/ANI1_subset/1
+++ b/tests/test_data/ANI1_subset/1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4a59e359a48b5001df66c31ceb0662fcd0deea32dff0c656a188a0d3b13fa1b
-size 63259

--- a/tests/test_data/ANI1_subset/10
+++ b/tests/test_data/ANI1_subset/10
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e597014c538415d27330329d9d0721612ac8259b43201203c00b97a0a0eab8d3
-size 63259

--- a/tests/test_data/ANI1_subset/11
+++ b/tests/test_data/ANI1_subset/11
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a897f5babfbff6923cb86ce7065414d0ea31f7e1d5bf23dd369028e939ec589f
-size 31890

--- a/tests/test_data/ANI1_subset/12
+++ b/tests/test_data/ANI1_subset/12
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2d6cd511d22357f7d0d67a23047cd88cf093d78605cc777c547749c9488ed67
-size 63259

--- a/tests/test_data/ANI1_subset/13
+++ b/tests/test_data/ANI1_subset/13
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a08b39de994ad9d1e802d12f41da5a2fd7582a0cafb839ec3f1d913346db07e
-size 63259

--- a/tests/test_data/ANI1_subset/14
+++ b/tests/test_data/ANI1_subset/14
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e030846e943b308be07e84718d0c6c9fdeab4f74a1284a0827a26d67f57bb58
-size 94619

--- a/tests/test_data/ANI1_subset/15
+++ b/tests/test_data/ANI1_subset/15
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f383f543851221abc48793588774a609309ab0696e77f82fb291b714f260482
-size 63259

--- a/tests/test_data/ANI1_subset/16
+++ b/tests/test_data/ANI1_subset/16
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d605c59677800e1982b7ee337a83ca9e1faef14e0c864739b5a320c473260ce
-size 173019

--- a/tests/test_data/ANI1_subset/17
+++ b/tests/test_data/ANI1_subset/17
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7d507455a4e044cc41381f734ce90d14977b57f4328991e5932d51cec730dbc
-size 157339

--- a/tests/test_data/ANI1_subset/18
+++ b/tests/test_data/ANI1_subset/18
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15280f3bec5c2f0c1e291fdef48a03dddc8263ef6f1294533eda27ee06498850
-size 94619

--- a/tests/test_data/ANI1_subset/19
+++ b/tests/test_data/ANI1_subset/19
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03897b0ea651b76aa96d7ee87f02f6a80a69db041769cef789743768afd8dd7b
-size 78939

--- a/tests/test_data/ANI1_subset/2
+++ b/tests/test_data/ANI1_subset/2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e417e13a9ba319d1f6e1348e6495889475b30529f8c56c8a0c8cd406be6f637
-size 47576

--- a/tests/test_data/ANI1_subset/20
+++ b/tests/test_data/ANI1_subset/20
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c6ebc0a44b6a30b72397a9a51d90f59e363a6f47c385d38c5f32ed518a19934
-size 110299

--- a/tests/test_data/ANI1_subset/21
+++ b/tests/test_data/ANI1_subset/21
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ad33a5b61befce2044275155aed1a333799f8957095c5d02d578ad6148ebdbb
-size 94619

--- a/tests/test_data/ANI1_subset/22
+++ b/tests/test_data/ANI1_subset/22
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de253fe10503296816c8b0ad505cce0494eba6e4817ba815072743abe01150e7
-size 110299

--- a/tests/test_data/ANI1_subset/23
+++ b/tests/test_data/ANI1_subset/23
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c9e08e0ed05d05613716a28f1e89b868ae2eaf040ebf2c50a56650d9bb24702
-size 141659

--- a/tests/test_data/ANI1_subset/24
+++ b/tests/test_data/ANI1_subset/24
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c56618059d394355cee2236571e7cd454cd478f8b345c220542ba2fbe977a53
-size 125979

--- a/tests/test_data/ANI1_subset/25
+++ b/tests/test_data/ANI1_subset/25
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a25e4b2ab8385c8cfc58fdc375fe2d57c7a711f776ae24ae527ed9f73af3b8b
-size 110299

--- a/tests/test_data/ANI1_subset/26
+++ b/tests/test_data/ANI1_subset/26
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed5c9dab7ee39d37c3c9743075ce82ce4b55b0d7b3ca402dcb28e2831b8596b9
-size 63259

--- a/tests/test_data/ANI1_subset/27
+++ b/tests/test_data/ANI1_subset/27
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5bfdf62e74e8cbc0e51a7c2aeda25566dc92b911f5055b1b5cda61fe0653513
-size 78939

--- a/tests/test_data/ANI1_subset/28
+++ b/tests/test_data/ANI1_subset/28
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27002be256db33e8bc0e84ef581f0f8244654f0df31191626628e6da26cfee84
-size 141659

--- a/tests/test_data/ANI1_subset/29
+++ b/tests/test_data/ANI1_subset/29
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:56677a701687a124caa60d208d52c3b225c80de6054673d9c79d50c6b251edfb
-size 157339

--- a/tests/test_data/ANI1_subset/3
+++ b/tests/test_data/ANI1_subset/3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d68278aab2e5a0643b0b5da575d30346fcba93dfd7132acc74e1a54d411b2c6
-size 125979

--- a/tests/test_data/ANI1_subset/30
+++ b/tests/test_data/ANI1_subset/30
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f6cf84834f048e79b5e1f842a3bbdf78664cc40a147f6ada4a9c9e4dad08b4d
-size 141659

--- a/tests/test_data/ANI1_subset/31
+++ b/tests/test_data/ANI1_subset/31
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00d6430a5e485aeef91fb542163deae16b4678e91820101d8a3761d25967970a
-size 141659

--- a/tests/test_data/ANI1_subset/32
+++ b/tests/test_data/ANI1_subset/32
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30d764f4ac52ef6249b5f6e7e7253570c384bb91f36a1177e14052da82d581a6
-size 110299

--- a/tests/test_data/ANI1_subset/33
+++ b/tests/test_data/ANI1_subset/33
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02cf07f45d5d12b506a23c934e4f1d1c21bd78f1dcda8ad5a299e7a5806468d9
-size 47576

--- a/tests/test_data/ANI1_subset/34
+++ b/tests/test_data/ANI1_subset/34
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53285c08c9880df3a41e882a7256ade7fd6f49ca357305ed18b45dd52c61f2a6
-size 94619

--- a/tests/test_data/ANI1_subset/35
+++ b/tests/test_data/ANI1_subset/35
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:589cd5e32b0e74d73eb60d1f3e98d30dfdac413b2a2890c852ca587f766af1a6
-size 110299

--- a/tests/test_data/ANI1_subset/36
+++ b/tests/test_data/ANI1_subset/36
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa01787c924b876ac9e50d89e189f0218e842ca296e316281e7d89e1c392b1af
-size 204379

--- a/tests/test_data/ANI1_subset/37
+++ b/tests/test_data/ANI1_subset/37
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:612671b15b44b566690f3102de977268728361a3a4f349df504bd9eef0ab1fab
-size 188699

--- a/tests/test_data/ANI1_subset/38
+++ b/tests/test_data/ANI1_subset/38
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:219ef8a1c295510b443c33fc4746012de957246dad88344f61385920ffb94c62
-size 94619

--- a/tests/test_data/ANI1_subset/39
+++ b/tests/test_data/ANI1_subset/39
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2b077e776a1b36d5ad6dc8750c6991c43f292c932bbb50a2bfb820c7a014328
-size 220059

--- a/tests/test_data/ANI1_subset/4
+++ b/tests/test_data/ANI1_subset/4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:102616af8d609a51d54da75bd574ccaac4fbe5e24db6876e6fd91ae32034eb67
-size 110299

--- a/tests/test_data/ANI1_subset/40
+++ b/tests/test_data/ANI1_subset/40
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac72e68435a4e46eb7f5f58c85f589193c4f19c582c829a0faeb1e44bbcc8a93
-size 204379

--- a/tests/test_data/ANI1_subset/41
+++ b/tests/test_data/ANI1_subset/41
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a784f91664567dca6488e337455f4d72c3c44e63aebe29bb04518fa060f5a56b
-size 188699

--- a/tests/test_data/ANI1_subset/42
+++ b/tests/test_data/ANI1_subset/42
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d3c54b09677510c690e88ae3f95780f7fc63df5334882220d459a9e24c85ebf
-size 188699

--- a/tests/test_data/ANI1_subset/43
+++ b/tests/test_data/ANI1_subset/43
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eeabb5f2cdd055517c0fb25817ee88d1c1f03def6370a4521379122f02a14c7b
-size 173019

--- a/tests/test_data/ANI1_subset/44
+++ b/tests/test_data/ANI1_subset/44
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b984388f9486eaf0903efa06e3cc936d356862bfe8ff32d7aa50a74f329bd4c
-size 157339

--- a/tests/test_data/ANI1_subset/45
+++ b/tests/test_data/ANI1_subset/45
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f65edca6badf33f2e949323b6aa52c391c22224d1372409d7c88cb84934b6141
-size 204379

--- a/tests/test_data/ANI1_subset/46
+++ b/tests/test_data/ANI1_subset/46
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e5200b266c6f809101c95bad2522e11dae4291d27a19813df656d5555786967
-size 188699

--- a/tests/test_data/ANI1_subset/47
+++ b/tests/test_data/ANI1_subset/47
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cee6dcaf42683e79a5cf213240df376bb7462d94c4b5cbcdfab8ca2571e5ed89
-size 188699

--- a/tests/test_data/ANI1_subset/48
+++ b/tests/test_data/ANI1_subset/48
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66409f05de4606915d88a510073d882daaf8659199305ee6c45d434fe5dbe5a4
-size 204379

--- a/tests/test_data/ANI1_subset/49
+++ b/tests/test_data/ANI1_subset/49
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e170f4e7ff2502ff0a64d7e106bc40a19fc5f1567c04172fc917c4d5e1f94edb
-size 157339

--- a/tests/test_data/ANI1_subset/5
+++ b/tests/test_data/ANI1_subset/5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcde12f48203e0a011911516c2985cce89a7d625abad1662297b25829a767de5
-size 31890

--- a/tests/test_data/ANI1_subset/50
+++ b/tests/test_data/ANI1_subset/50
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3d891b79716da94bddaf501166e94c1763dd81d14093762249079ae30947e72
-size 141659

--- a/tests/test_data/ANI1_subset/51
+++ b/tests/test_data/ANI1_subset/51
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a43878969570b7fbe95fd44c4767c785843ca06b96c737841d5c0484280142e
-size 173019

--- a/tests/test_data/ANI1_subset/52
+++ b/tests/test_data/ANI1_subset/52
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:053ef39062f427de33ce984865648ea0480bba77134f984cfeda25421158617f
-size 157339

--- a/tests/test_data/ANI1_subset/53
+++ b/tests/test_data/ANI1_subset/53
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1dee7dc3877b427e1a8ee43a875dc14b1a4b88b5fe02f629a38947b13ad7c3da
-size 125979

--- a/tests/test_data/ANI1_subset/54
+++ b/tests/test_data/ANI1_subset/54
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bff0018df8bb9211b6c79c6184101befa1ed8356cd70e68c7dfc173fcb076521
-size 110299

--- a/tests/test_data/ANI1_subset/55
+++ b/tests/test_data/ANI1_subset/55
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c485d7698a403764026441e52f1e4dbdeed7be5f7d0c3612d32a7a89f0b7767e
-size 157339

--- a/tests/test_data/ANI1_subset/56
+++ b/tests/test_data/ANI1_subset/56
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54b3409bed6925595edb2a94f63d1f97cd771c888f40de9c5e199a0265c8be47
-size 141659

--- a/tests/test_data/ANI1_subset/57
+++ b/tests/test_data/ANI1_subset/57
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8df511e2dc5c5e1a44600981376e8d98fe5ce128f4bce298d8043374a1338961
-size 141659

--- a/tests/test_data/ANI1_subset/58
+++ b/tests/test_data/ANI1_subset/58
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bb17ca4edc6a19c3e6537b6ffb357e80b946ca9400f5de72293fb0178a96fed
-size 125979

--- a/tests/test_data/ANI1_subset/59
+++ b/tests/test_data/ANI1_subset/59
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:643d2dd8430d688ffd1a331fb245d41fbf661da8a5ea7734d4c14219a2fdf436
-size 188699

--- a/tests/test_data/ANI1_subset/6
+++ b/tests/test_data/ANI1_subset/6
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49ec3e6cea6334f852b265199e47f241c41bb1ee76c0dbfdb453bd2f7bccce31
-size 78939

--- a/tests/test_data/ANI1_subset/60
+++ b/tests/test_data/ANI1_subset/60
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4e32d28f817077b248f7c10b0f5da90646e86cec0198edfbfa46e5deeb0a971
-size 125979

--- a/tests/test_data/ANI1_subset/61
+++ b/tests/test_data/ANI1_subset/61
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc0eb7629fcf527c6c74f0023435b6c6978d7a7d4aea88f83a529c34f35af03e
-size 110299

--- a/tests/test_data/ANI1_subset/62
+++ b/tests/test_data/ANI1_subset/62
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0de4632626aa724985d03810fa8fd00deb23bb3f1605444f35598911c54632b3
-size 157339

--- a/tests/test_data/ANI1_subset/63
+++ b/tests/test_data/ANI1_subset/63
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:378887883221af81b919adf232bd872a527d619e7171b7d675f5baf8f5adf341
-size 157339

--- a/tests/test_data/ANI1_subset/64
+++ b/tests/test_data/ANI1_subset/64
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:570d309ae971c35119dd7709a9e5e9d7f73dc858a191aed0020ca388ef1b38c0
-size 125979

--- a/tests/test_data/ANI1_subset/65
+++ b/tests/test_data/ANI1_subset/65
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7119a95bb500823e739a1c38c8bd06e4cd7321212f4f48e3f90c26ced5f810e
-size 141659

--- a/tests/test_data/ANI1_subset/66
+++ b/tests/test_data/ANI1_subset/66
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f1b87e6a6c07b804f284e7e225b47ccd02eaec60cc91ae470ac67dfef986d39
-size 157339

--- a/tests/test_data/ANI1_subset/67
+++ b/tests/test_data/ANI1_subset/67
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:961cc1e88cdcc212f99f780731ec5bdb881b6003ea379c5c59003ab69918efef
-size 141659

--- a/tests/test_data/ANI1_subset/68
+++ b/tests/test_data/ANI1_subset/68
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d157fe4b0c3d6b7af247866b1ca4d38744766829e39300e0e18b5fb299897d6
-size 125979

--- a/tests/test_data/ANI1_subset/69
+++ b/tests/test_data/ANI1_subset/69
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1cc6a3a18479307d84ca1d05e1c5d0dbc1869f5afabeddab8b30b9e14b04e61e
-size 157339

--- a/tests/test_data/ANI1_subset/7
+++ b/tests/test_data/ANI1_subset/7
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb683d4ba0b7fddba14c120c1d1ad1f3d80443186a6022cef10a8921c2d9eac9
-size 47576

--- a/tests/test_data/ANI1_subset/70
+++ b/tests/test_data/ANI1_subset/70
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec03aec5b95d5c93cb2f9ff3fea8b3e6d030c14bf64f20096865c3001dc16b81
-size 157339

--- a/tests/test_data/ANI1_subset/71
+++ b/tests/test_data/ANI1_subset/71
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0210da8591a91859c7e1bfcc6710a9436c32b17f0aeeefd09da7442e229aaec
-size 125979

--- a/tests/test_data/ANI1_subset/72
+++ b/tests/test_data/ANI1_subset/72
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:475595cae6dc2fc7a11040322164643c9b22b34fb44a73f6c7299c84880b1942
-size 110299

--- a/tests/test_data/ANI1_subset/73
+++ b/tests/test_data/ANI1_subset/73
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a334de4ed26c0c8ea9b5200c6f82325c288561cf65f5b1a3f4f03fc8f8696b6
-size 94619

--- a/tests/test_data/ANI1_subset/74
+++ b/tests/test_data/ANI1_subset/74
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf69a8883731e55620d03e411727605142d24f93fdd94a22b473c739c821cd7c
-size 78939

--- a/tests/test_data/ANI1_subset/75
+++ b/tests/test_data/ANI1_subset/75
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f21c35adfa84341605ff16d9b8bbdbab760a40b339cb840f000aaa7dfe2aceca
-size 63259

--- a/tests/test_data/ANI1_subset/76
+++ b/tests/test_data/ANI1_subset/76
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10db05f95adde4e446aef15700f5ae72c42fd039043ab7f893c0f294e4e23e72
-size 125979

--- a/tests/test_data/ANI1_subset/77
+++ b/tests/test_data/ANI1_subset/77
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7aa2e2151936324af0e6895d248f5ae4509018a78e0abc7be9e9861409aa5036
-size 125979

--- a/tests/test_data/ANI1_subset/78
+++ b/tests/test_data/ANI1_subset/78
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abb8fb93da66632d4cd61754f45736dc764b2174eb2dbe7df3445d32dcc8cd4e
-size 94619

--- a/tests/test_data/ANI1_subset/79
+++ b/tests/test_data/ANI1_subset/79
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d8a906ab9706485679f18e3635cb1327a38d8f277b996322485fc09de53a78e
-size 78939

--- a/tests/test_data/ANI1_subset/8
+++ b/tests/test_data/ANI1_subset/8
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42c9ea4ff2909d8ecb67751cc6384d528f859923220c3633ce461c1ca601e0ec
-size 94619

--- a/tests/test_data/ANI1_subset/80
+++ b/tests/test_data/ANI1_subset/80
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe8407a960da41057e3aae7fa5414e7b1374a6938a05a18f8920b0b0c9c9c7ce
-size 94619

--- a/tests/test_data/ANI1_subset/81
+++ b/tests/test_data/ANI1_subset/81
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81ea5c514c1b6c0c18759f797dd80d472d00159f8dbde63fd82e8f5e7d0ff47f
-size 157339

--- a/tests/test_data/ANI1_subset/82
+++ b/tests/test_data/ANI1_subset/82
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de9e1a9b6356c54740d1735ae9b928d162cc9c7d74bf2aecf8cd1d736f68d739
-size 157339

--- a/tests/test_data/ANI1_subset/83
+++ b/tests/test_data/ANI1_subset/83
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:499446e1bf07bb588d8a5afbfb3f03b54dd891a750bd0f7033ac504fe742bcc9
-size 141659

--- a/tests/test_data/ANI1_subset/84
+++ b/tests/test_data/ANI1_subset/84
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb1b17ed93695e3eed3a5fbe7f39057f88d75533b002b348624a63346c7a4292
-size 188699

--- a/tests/test_data/ANI1_subset/85
+++ b/tests/test_data/ANI1_subset/85
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f16649665031a559c40f4f8e7495dae2875cbad77fcd045119b0065b53b85a3
-size 173019

--- a/tests/test_data/ANI1_subset/86
+++ b/tests/test_data/ANI1_subset/86
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ed1dcf125db62ac6d665c9c03fe57c324fec1e4ac0339b17ec55de91d95e4e7
-size 157339

--- a/tests/test_data/ANI1_subset/87
+++ b/tests/test_data/ANI1_subset/87
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4196c2b13b29e5c936ee3ad4ad2bd5cc1d9b35fdffd8aece07650caafab65a4d
-size 173019

--- a/tests/test_data/ANI1_subset/88
+++ b/tests/test_data/ANI1_subset/88
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e424a3e369328ca72f492ce1f0b67a3ee18a309e846eaef099e713870317bdc8
-size 157339

--- a/tests/test_data/ANI1_subset/89
+++ b/tests/test_data/ANI1_subset/89
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:22d960583cc618a27d67990e9a94b4c2bd910398aadf71c02ba10ca68e5f8139
-size 173019

--- a/tests/test_data/ANI1_subset/9
+++ b/tests/test_data/ANI1_subset/9
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1c5b11541219b5eb643642a33694afa4769c39d991ed9fa8a9704db484c9385
-size 94619

--- a/tests/test_data/ANI1_subset/90
+++ b/tests/test_data/ANI1_subset/90
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45b22a651cc4e5059ca6b7601224a4f84d6800d66d5d7cd00167a568c619ea82
-size 141659

--- a/tests/test_data/ANI1_subset/91
+++ b/tests/test_data/ANI1_subset/91
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c59c40a8f00e4e8a80819fbfe4d3cabeb7c72f387ceb24c71c22ad1ddb7aac36
-size 188699

--- a/tests/test_data/ANI1_subset/92
+++ b/tests/test_data/ANI1_subset/92
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7bcb6634a6f31464685ef589127f1c0af3773380a85056012ca5e5c825d9e7ee
-size 173019

--- a/tests/test_data/ANI1_subset/93
+++ b/tests/test_data/ANI1_subset/93
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:51fe0f21048896ce46bf76c86da8fa955936ac982ac823962ee1fc3b26df7d85
-size 157339

--- a/tests/test_data/ANI1_subset/94
+++ b/tests/test_data/ANI1_subset/94
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32dbf3d1fafcaeda0205b88f169eb59680ee96a885a0245f8116403304028f74
-size 125979

--- a/tests/test_data/ANI1_subset/95
+++ b/tests/test_data/ANI1_subset/95
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb4322b51a8e5f1c1f6b0484ac1c21fc54c06c3199fc6dd2427f0c66e2ee66f5
-size 141659

--- a/tests/test_data/ANI1_subset/96
+++ b/tests/test_data/ANI1_subset/96
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebf3fdb1956744abce85880f22b480ba3c6724c0885ab2ed6b58732d3be0a1b5
-size 125979

--- a/tests/test_data/NIST
+++ b/tests/test_data/NIST
@@ -1,0 +1,1 @@
+../../download/test_data/NIST/

--- a/tests/test_data/NIST/all
+++ b/tests/test_data/NIST/all
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa456a4509af6a0539f95a940366f5c6afae068183cb894bb314bc4e20e0f035
-size 101700152

--- a/tests/test_data/NeuroChemOptimized
+++ b/tests/test_data/NeuroChemOptimized
@@ -1,0 +1,1 @@
+../../download/test_data/NeuroChemOptimized/

--- a/tests/test_data/NeuroChemOptimized/all
+++ b/tests/test_data/NeuroChemOptimized/all
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4ce31f14128ec691bdfd88f5083aed817a2a0804d2ff93111e3207a7aced4b9
-size 282995

--- a/tests/test_data/benzene-md
+++ b/tests/test_data/benzene-md
@@ -1,0 +1,1 @@
+../../download/test_data/benzene-md/

--- a/tests/test_data/benzene-md/0.dat
+++ b/tests/test_data/benzene-md/0.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae459af07118136582f6891c5c7f2e79a876f102f7c4fe1e226db1129995a0a2
-size 1365788

--- a/tests/test_data/benzene-md/1.dat
+++ b/tests/test_data/benzene-md/1.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06a3e6d8c2c213910b2a279a580b5067fc872bdf275755c60fe2ab815513b3e5
-size 1365788

--- a/tests/test_data/benzene-md/2.dat
+++ b/tests/test_data/benzene-md/2.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:563c6774de9f71203f7dc28e7f97f3440dd6836bddfc9a47806c3779b79d5ec2
-size 1365788

--- a/tests/test_data/benzene-md/3.dat
+++ b/tests/test_data/benzene-md/3.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f1362e91beff914273aa0edabd93507852c47d880e3034dcb638d4909b4933a
-size 1365788

--- a/tests/test_data/benzene-md/4.dat
+++ b/tests/test_data/benzene-md/4.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4919564f277fd118a512406a6bb0727e3b65d52f586e55ee1f7bc45dd94086e
-size 1365788

--- a/tests/test_data/benzene-md/5.dat
+++ b/tests/test_data/benzene-md/5.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7f95be4a64ac8034841308f0ca82d577639d1d4fd3208940cb2afc46c32447f
-size 1365788

--- a/tests/test_data/benzene-md/6.dat
+++ b/tests/test_data/benzene-md/6.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10b7faa0f331bbb8bac03207b8f17e743adce80fdbafb0eb65b48168d93e50a1
-size 1365788

--- a/tests/test_data/benzene-md/7.dat
+++ b/tests/test_data/benzene-md/7.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9eb8d4d316eb3f3d8803679fbe2dfe4c686fd6a30750a1b99639901eb4edadb8
-size 1365788

--- a/tests/test_data/benzene-md/8.dat
+++ b/tests/test_data/benzene-md/8.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbd0321d13d7f8e177c5075c1e1283430303c239511d145f3e0d47664759b1f4
-size 1365788

--- a/tests/test_data/benzene-md/9.dat
+++ b/tests/test_data/benzene-md/9.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e410d806d4fc4860332ac40a6399972a85fbdddc24fdbdfded6785d8b1f215b
-size 1365788

--- a/tests/test_data/tripeptide-md
+++ b/tests/test_data/tripeptide-md
@@ -1,0 +1,1 @@
+../../download/test_data/tripeptide-md/

--- a/tests/test_data/tripeptide-md/0.dat
+++ b/tests/test_data/tripeptide-md/0.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd83df32cea5730a715271d5bc4dccb58411e7a5087520be46b172f5d40c9a36
-size 92303

--- a/tests/test_data/tripeptide-md/1.dat
+++ b/tests/test_data/tripeptide-md/1.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3d6709cfa4bd2f50bab14c9efeeb63aaafa82f5b0ebd62303d13b1b9f99a66e
-size 92303

--- a/tests/test_data/tripeptide-md/10.dat
+++ b/tests/test_data/tripeptide-md/10.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3d3a18c6e07daf75a97fc26b45d324b5155639433d011582c83b6b606296b37
-size 92303

--- a/tests/test_data/tripeptide-md/11.dat
+++ b/tests/test_data/tripeptide-md/11.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9493ab508d0dbcd5fb1f9473bd5f4eddaaaa3348205921f74f666acca831c13
-size 92303

--- a/tests/test_data/tripeptide-md/12.dat
+++ b/tests/test_data/tripeptide-md/12.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bffda6dc8cd189e2bd4dd8f4726d61a7c38b205475c1197f5ecc25f2f2b5137
-size 92303

--- a/tests/test_data/tripeptide-md/13.dat
+++ b/tests/test_data/tripeptide-md/13.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb642a609dbfd2cb8704c603032e349c0ab87eddb4bd79bdc90aa7bbbe508d34
-size 92303

--- a/tests/test_data/tripeptide-md/14.dat
+++ b/tests/test_data/tripeptide-md/14.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:56f001431d97660289323d95a4e4fde4be52c7fde3f69113b8e2372072631371
-size 92303

--- a/tests/test_data/tripeptide-md/15.dat
+++ b/tests/test_data/tripeptide-md/15.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c38af9e89a3277ba86ae5f1c6ba8e59b9fbf6a54fbcafa0fa363017b5daf4e5
-size 92303

--- a/tests/test_data/tripeptide-md/16.dat
+++ b/tests/test_data/tripeptide-md/16.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3974726d662bda4a08cd18d3e458866812a29c7b292d743850be2ac9d6f51f8
-size 92303

--- a/tests/test_data/tripeptide-md/17.dat
+++ b/tests/test_data/tripeptide-md/17.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05ec42b10275c476a75d1e1865cf6f31033d300e5768c7ff3d1dbbde1d7f9409
-size 92303

--- a/tests/test_data/tripeptide-md/18.dat
+++ b/tests/test_data/tripeptide-md/18.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6227c20b8479fda4970bee65ae4dbcd5920afc1b4ae4cde9f77aaa852849b8ea
-size 92303

--- a/tests/test_data/tripeptide-md/19.dat
+++ b/tests/test_data/tripeptide-md/19.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8cc77c802174128f0fa8b423bbffe0977664808839036b40e8363a42a5b1bcd1
-size 92303

--- a/tests/test_data/tripeptide-md/2.dat
+++ b/tests/test_data/tripeptide-md/2.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3446cbecbf7307f757d1cc9099b29625f17f0a1eadd955c311ca372b9e31804e
-size 92303

--- a/tests/test_data/tripeptide-md/20.dat
+++ b/tests/test_data/tripeptide-md/20.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5353dffe3be13e9eef7207817fc51acad3f380ca0f7a435dc3b5eb86d1871295
-size 92303

--- a/tests/test_data/tripeptide-md/21.dat
+++ b/tests/test_data/tripeptide-md/21.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c468ecd518a1b9e9ad3fa0d8e86b0764dca545e319441b082d555f4653898b78
-size 92303

--- a/tests/test_data/tripeptide-md/22.dat
+++ b/tests/test_data/tripeptide-md/22.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63227cedd2fde98b9a6a3859dd2a236127e076f9c3efa0e0524d8936f6a0e847
-size 92303

--- a/tests/test_data/tripeptide-md/23.dat
+++ b/tests/test_data/tripeptide-md/23.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bef59c4ac0940e8a769e40a82a71819819d1977039b2ff73650110f2eb76c81
-size 92303

--- a/tests/test_data/tripeptide-md/24.dat
+++ b/tests/test_data/tripeptide-md/24.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43ca58c784ce4445565aa13c22bc6fd42708cfcf2dcc2f1f5fcc48c3cf5fbf59
-size 92303

--- a/tests/test_data/tripeptide-md/25.dat
+++ b/tests/test_data/tripeptide-md/25.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c96372c7571afe4a9914ea1dbd35f5ff18808563b76ee921a1ef97f0b701e60
-size 92303

--- a/tests/test_data/tripeptide-md/26.dat
+++ b/tests/test_data/tripeptide-md/26.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b6a2d0f20cd5e2ed34a54be2857c75db568b2b37815b3c6e397e7f604789303
-size 92303

--- a/tests/test_data/tripeptide-md/27.dat
+++ b/tests/test_data/tripeptide-md/27.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b9d35bb54792514d33d66a39a6991c81b4c0714db2ecfec94ddf8150a33ba50
-size 92303

--- a/tests/test_data/tripeptide-md/28.dat
+++ b/tests/test_data/tripeptide-md/28.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd095ce92b79b294581b395ec828b8f0927a142c5496150006b47cca42266442
-size 92303

--- a/tests/test_data/tripeptide-md/29.dat
+++ b/tests/test_data/tripeptide-md/29.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2b4bc0e28aa1f29301263b54b942236297ef31a98956fa249bf078c66be1904
-size 92303

--- a/tests/test_data/tripeptide-md/3.dat
+++ b/tests/test_data/tripeptide-md/3.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bbf8fcee083cf7ba345a3d8e88c31a37120ca4994ab246276ae6f6d9ba359ed
-size 92303

--- a/tests/test_data/tripeptide-md/30.dat
+++ b/tests/test_data/tripeptide-md/30.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd90d34610f1818cce8b729bee0979365cfd88c26f7e59037e1335bdbb0f9c85
-size 92303

--- a/tests/test_data/tripeptide-md/31.dat
+++ b/tests/test_data/tripeptide-md/31.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53139d54bc0d3c611da8a8a51a5796b9d05132160eb01a59be6992304a1bc0e6
-size 92303

--- a/tests/test_data/tripeptide-md/32.dat
+++ b/tests/test_data/tripeptide-md/32.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:926db51661673470244c5e95aeeff20405e1aee09f7651ff349132cb8d05ddf0
-size 92303

--- a/tests/test_data/tripeptide-md/33.dat
+++ b/tests/test_data/tripeptide-md/33.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d22549084560f9d19478928ec2d3e0d2ee551c3fefb001e144d1a8a1f26509d6
-size 92303

--- a/tests/test_data/tripeptide-md/34.dat
+++ b/tests/test_data/tripeptide-md/34.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd4f1bc463d0b9bee23468fdd41842120b2421f2f3c43a258ffef22f2a08da85
-size 92303

--- a/tests/test_data/tripeptide-md/35.dat
+++ b/tests/test_data/tripeptide-md/35.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0947da4613dc403304c59c149412ed99b324fd40a5e9ec4811df87baa593bdd7
-size 92303

--- a/tests/test_data/tripeptide-md/36.dat
+++ b/tests/test_data/tripeptide-md/36.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a7ec2a8d7f8aba97306572fbd4d45f6e2afac4d261e7c2fd2c3486c1395d511
-size 92303

--- a/tests/test_data/tripeptide-md/37.dat
+++ b/tests/test_data/tripeptide-md/37.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85a0e856c6a54cd8b54c460858710e122bfb6acd0985c821894a2fc4b1bdfab8
-size 92303

--- a/tests/test_data/tripeptide-md/38.dat
+++ b/tests/test_data/tripeptide-md/38.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:831caa0db83673960fb7d3d36f1d0af80a1482c6029d04293fc84a02238fa8d3
-size 92303

--- a/tests/test_data/tripeptide-md/39.dat
+++ b/tests/test_data/tripeptide-md/39.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da6300cbcd6b098bd6281e27696ea69da4291e69144a53d62e0cd642e803befa
-size 92303

--- a/tests/test_data/tripeptide-md/4.dat
+++ b/tests/test_data/tripeptide-md/4.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c5dd48a70f6d9c70058fe372775f7e9c5610a1257805076e7aed1e49e22a64d
-size 92303

--- a/tests/test_data/tripeptide-md/40.dat
+++ b/tests/test_data/tripeptide-md/40.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12aab41e4d2338b192b809af5677a3202de6941dce6c0fe8da35cbc7063ac448
-size 92303

--- a/tests/test_data/tripeptide-md/41.dat
+++ b/tests/test_data/tripeptide-md/41.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e9730bbed057e29e50eb67bf8708f946a924d36049c867b5fd140101080136a
-size 92303

--- a/tests/test_data/tripeptide-md/42.dat
+++ b/tests/test_data/tripeptide-md/42.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd767db478c580318964f45b9007ece05f452d4315069545a92ac9fa654e23d3
-size 92303

--- a/tests/test_data/tripeptide-md/43.dat
+++ b/tests/test_data/tripeptide-md/43.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fcf2717b459ed45cea14061417bc79b34b1e0b38ac587a68056a72fabe5cbb98
-size 92303

--- a/tests/test_data/tripeptide-md/44.dat
+++ b/tests/test_data/tripeptide-md/44.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:226422c51a72ce853dcde852575dde7a1290d083eec184f3725027a95838e92c
-size 92303

--- a/tests/test_data/tripeptide-md/45.dat
+++ b/tests/test_data/tripeptide-md/45.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5c69f11330ddfa6e5ff201c5d72df947314cd2d061a0017038daf2610eda2d1
-size 92303

--- a/tests/test_data/tripeptide-md/46.dat
+++ b/tests/test_data/tripeptide-md/46.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7bcdbc03e470bbbc358f3d5efbe0c3043abb4eaafbc445b9a28f081a84ca51f6
-size 92303

--- a/tests/test_data/tripeptide-md/47.dat
+++ b/tests/test_data/tripeptide-md/47.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8892e62d5e06a73395432d131d25f97ad76901aa8ebe2366134b7811547161cd
-size 92303

--- a/tests/test_data/tripeptide-md/48.dat
+++ b/tests/test_data/tripeptide-md/48.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f158be12958ce052bd3f14a3c4a1b966f801b51de8d07f2d4ffd08a9390b5f6
-size 92303

--- a/tests/test_data/tripeptide-md/49.dat
+++ b/tests/test_data/tripeptide-md/49.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3f6b184fdf3c1e189a0db26f39f329f0b1eb7c6ed9df47c8778616edccc7d6f
-size 92303

--- a/tests/test_data/tripeptide-md/5.dat
+++ b/tests/test_data/tripeptide-md/5.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28431a8a26c3328432f427ec8a15075dc30ad5adc955a30d1a3847a639d033b6
-size 92303

--- a/tests/test_data/tripeptide-md/50.dat
+++ b/tests/test_data/tripeptide-md/50.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6204d23eb89a6e7b9cc17fab059290ee4e99d253c9764a1f8d73ade14def57ef
-size 92303

--- a/tests/test_data/tripeptide-md/51.dat
+++ b/tests/test_data/tripeptide-md/51.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36828d81a8b02e7c01445f65b3ccf629ea77830ca5ca1f3f3b74b0d5c603c121
-size 92303

--- a/tests/test_data/tripeptide-md/52.dat
+++ b/tests/test_data/tripeptide-md/52.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c3af596ffa79f10a7ef1ed04fac3f929355abd57765ff6108eb9862d856ca47
-size 92303

--- a/tests/test_data/tripeptide-md/53.dat
+++ b/tests/test_data/tripeptide-md/53.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:967a03a7c5d0a2cedb1c3232f770b49c4e023c0c73b0cc799e787add7be2c4b5
-size 92303

--- a/tests/test_data/tripeptide-md/54.dat
+++ b/tests/test_data/tripeptide-md/54.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0cd60b36b09083e804e1301ee3d5273e18ebd278e523bab242ab7ddde4e0871
-size 92303

--- a/tests/test_data/tripeptide-md/55.dat
+++ b/tests/test_data/tripeptide-md/55.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ea0604a918dcea99821e9cd2b081b598a08af04c78c58de04f11b0afe97d658
-size 92303

--- a/tests/test_data/tripeptide-md/56.dat
+++ b/tests/test_data/tripeptide-md/56.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cd4631375d4def739e550518f890c8293f12e7a790a7c4667804754bfa789a8
-size 92303

--- a/tests/test_data/tripeptide-md/57.dat
+++ b/tests/test_data/tripeptide-md/57.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3f568f6b732137283b557a1349c2a0d32daeaf3205b83f94037b08fb068f91d
-size 92303

--- a/tests/test_data/tripeptide-md/58.dat
+++ b/tests/test_data/tripeptide-md/58.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e23e3111b282302bb5cd9e81e9778f2904c1df932a421bcaab5a92b4fdbde1d0
-size 92303

--- a/tests/test_data/tripeptide-md/59.dat
+++ b/tests/test_data/tripeptide-md/59.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81ab5e0d337eece6bfa5dfc91fd57b59b54ce8e698b91a193a6d5f1ce11150dc
-size 92303

--- a/tests/test_data/tripeptide-md/6.dat
+++ b/tests/test_data/tripeptide-md/6.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b58561fc194c43b5dff3b06164589d0183c87b2a9fb1e605efb3982b175dfc1f
-size 92303

--- a/tests/test_data/tripeptide-md/60.dat
+++ b/tests/test_data/tripeptide-md/60.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f48a804d65c065796ea3f88bc2207eca1b3a0718128dd54d1ee20a0eab6d161
-size 92303

--- a/tests/test_data/tripeptide-md/61.dat
+++ b/tests/test_data/tripeptide-md/61.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57f53aa73a529773676792f554c533ed66333c44484deb6cf6143c21600507dd
-size 92303

--- a/tests/test_data/tripeptide-md/62.dat
+++ b/tests/test_data/tripeptide-md/62.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:137564c681a1ccbb92fb4d90918a551b00ec4cf21100f4faf48701080ad89b20
-size 92303

--- a/tests/test_data/tripeptide-md/63.dat
+++ b/tests/test_data/tripeptide-md/63.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:358eb5d2711e386866adc71534e06905948fcc237dfcbf878ebb1ca13a619ed1
-size 92303

--- a/tests/test_data/tripeptide-md/64.dat
+++ b/tests/test_data/tripeptide-md/64.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29a0f55a03e9106ccc77ac3bb694f70420abec2ef87f003c36df3f763791047e
-size 92303

--- a/tests/test_data/tripeptide-md/65.dat
+++ b/tests/test_data/tripeptide-md/65.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:988490091049b25fdda56a4dbf0c6fa7110bdce76457f5a6a344e0389d22fdba
-size 92303

--- a/tests/test_data/tripeptide-md/66.dat
+++ b/tests/test_data/tripeptide-md/66.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c89ef6f9ef8bde3beab168d48e7890cd89f967a9bf7f4dbd1fca283d16b98cb
-size 92303

--- a/tests/test_data/tripeptide-md/67.dat
+++ b/tests/test_data/tripeptide-md/67.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d73169bde38be82276d2e78abbfa08924581320d475c5f08ce785562c7899764
-size 92303

--- a/tests/test_data/tripeptide-md/68.dat
+++ b/tests/test_data/tripeptide-md/68.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f71b8989955b8df9813e29ad8d135496169066c29f955b758bdbbb5537a60a3
-size 92303

--- a/tests/test_data/tripeptide-md/69.dat
+++ b/tests/test_data/tripeptide-md/69.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82cc357855abab804be65e79e4d4976de0955e7f9882eaf104950833c3be44fc
-size 92303

--- a/tests/test_data/tripeptide-md/7.dat
+++ b/tests/test_data/tripeptide-md/7.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbfcd6058bd48972edf54935c0daca46e75c81331d790b9457b89766a5123b6f
-size 92303

--- a/tests/test_data/tripeptide-md/70.dat
+++ b/tests/test_data/tripeptide-md/70.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:320d2392ff97f5973b99b6e974c2050104f9ec7b80d20772af3ae5a74de59519
-size 92303

--- a/tests/test_data/tripeptide-md/71.dat
+++ b/tests/test_data/tripeptide-md/71.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a259fbac06a70c6c11c2cb42d7afc0a2281b8ec0ae5e37c9017c5e845cee4715
-size 92303

--- a/tests/test_data/tripeptide-md/72.dat
+++ b/tests/test_data/tripeptide-md/72.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee5db99735d295a8eae43aa3e2e12258f791a25fc2fe453cda96088ffac461da
-size 92303

--- a/tests/test_data/tripeptide-md/73.dat
+++ b/tests/test_data/tripeptide-md/73.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00420838c2434dbb1bd0b4fa073f9bdd34d37fa7cf931b90f9f09c1b43e34c8b
-size 92303

--- a/tests/test_data/tripeptide-md/74.dat
+++ b/tests/test_data/tripeptide-md/74.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24d3f931f2f4c0fd4c5c1f31072f7b50cc5cb9de6b97ca87736a2bb40bc7c37a
-size 92303

--- a/tests/test_data/tripeptide-md/75.dat
+++ b/tests/test_data/tripeptide-md/75.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52e060b3a5927c59b2dfe10aa4fabeab4d54821267c61f5ad7527dcf200ff5d2
-size 92303

--- a/tests/test_data/tripeptide-md/76.dat
+++ b/tests/test_data/tripeptide-md/76.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1decb528ce8a79c7f0622786ea593c37b293c5cd67bc2b5b8f409654a6a730bf
-size 92303

--- a/tests/test_data/tripeptide-md/77.dat
+++ b/tests/test_data/tripeptide-md/77.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b4caa634108ac80030e25e76e561eadedeefc643c5769411574f72b08c7a4b8
-size 92303

--- a/tests/test_data/tripeptide-md/78.dat
+++ b/tests/test_data/tripeptide-md/78.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd4042a729757942fd03aa5b036d7b657e969390c37e14e89f57f10d8ddd61e5
-size 92303

--- a/tests/test_data/tripeptide-md/79.dat
+++ b/tests/test_data/tripeptide-md/79.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6131fba0e632f00bc9ff84866cd707bbf87d253c92cf017625511d77cfa7e14
-size 92303

--- a/tests/test_data/tripeptide-md/8.dat
+++ b/tests/test_data/tripeptide-md/8.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f99f1379f7d6c729301a6c5a0d51dc907f68c4a7d0197a29468115dfe155859
-size 92303

--- a/tests/test_data/tripeptide-md/80.dat
+++ b/tests/test_data/tripeptide-md/80.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:305b3b3448c0ac943290f0b31097ee83532e930e98864b44d7a6341b58350edc
-size 92303

--- a/tests/test_data/tripeptide-md/81.dat
+++ b/tests/test_data/tripeptide-md/81.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32a9bff77357eed117dc7479d9615e6eb74a4e33b25540cdd7f605dd39cfa26b
-size 92303

--- a/tests/test_data/tripeptide-md/82.dat
+++ b/tests/test_data/tripeptide-md/82.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe4cd18bab2d67ace994c46bebdd4969b9acc344a442d0ed441c0f605f79b9c5
-size 92303

--- a/tests/test_data/tripeptide-md/83.dat
+++ b/tests/test_data/tripeptide-md/83.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:412bb974aedc72263e16fd0d7d849423199e2fc6ab392fa3a212ab616cc48341
-size 92303

--- a/tests/test_data/tripeptide-md/84.dat
+++ b/tests/test_data/tripeptide-md/84.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96b566f7f57fd37b90af8799f1ac2212a334ba17aeb3cf6c7bd2af9262429581
-size 92303

--- a/tests/test_data/tripeptide-md/85.dat
+++ b/tests/test_data/tripeptide-md/85.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f9c5803b6e9fc0d4c81468480f47c6dbd4d9812260e672615444a259d31a28b
-size 92303

--- a/tests/test_data/tripeptide-md/86.dat
+++ b/tests/test_data/tripeptide-md/86.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29dd7a56d2063e87ace685c2150cef81eca9e629239e10daeb2ecb10701ec346
-size 92303

--- a/tests/test_data/tripeptide-md/87.dat
+++ b/tests/test_data/tripeptide-md/87.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3baf75e340412567b0812750bc363c6ecf133ef773728b770ba79a564cde45c5
-size 92303

--- a/tests/test_data/tripeptide-md/88.dat
+++ b/tests/test_data/tripeptide-md/88.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e59150b941497f44568f6ec3c5b137c7907985ed346a0c830d29fc26fce6a7c
-size 92303

--- a/tests/test_data/tripeptide-md/89.dat
+++ b/tests/test_data/tripeptide-md/89.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6a31b901058abc4ac0d33a02377d678e9ccec1019468d4329fb734a63fdcb57
-size 92303

--- a/tests/test_data/tripeptide-md/9.dat
+++ b/tests/test_data/tripeptide-md/9.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55261f6d02a27434ff021c77705bb54ba9a3533d26ca56c049c51fce0479f723
-size 92303

--- a/tests/test_data/tripeptide-md/90.dat
+++ b/tests/test_data/tripeptide-md/90.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d6980ac7055b35d11b08f6b0101508e995d37256ef8d0c1649e5e7bbe94088d
-size 92303

--- a/tests/test_data/tripeptide-md/91.dat
+++ b/tests/test_data/tripeptide-md/91.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da66bc85deb4bba681beead7c0e2e386875012ffe66d89630f4d6c314c8d543f
-size 92303

--- a/tests/test_data/tripeptide-md/92.dat
+++ b/tests/test_data/tripeptide-md/92.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe3b84052286ef9083c83625f63961f7a25013130cbfa78d1ed750687a35ced2
-size 92303

--- a/tests/test_data/tripeptide-md/93.dat
+++ b/tests/test_data/tripeptide-md/93.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3eb25d9515e195201732076127793277219ddef03f012b6d417b37e3cc0a096d
-size 92303

--- a/tests/test_data/tripeptide-md/94.dat
+++ b/tests/test_data/tripeptide-md/94.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:122b2c427e396c604ffa25b5c3c20abc1c844c35580bf18d6cc5513dfb1c9b1f
-size 92303

--- a/tests/test_data/tripeptide-md/95.dat
+++ b/tests/test_data/tripeptide-md/95.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eab9be10e93a0f751a55665acbd21590f8fce0f4d5d012205924f5957371a502
-size 92303

--- a/tests/test_data/tripeptide-md/96.dat
+++ b/tests/test_data/tripeptide-md/96.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2f42ddf031fe20710e942ab511490d381654b9d65e25149dfb5fff122720b0e
-size 92303

--- a/tests/test_data/tripeptide-md/97.dat
+++ b/tests/test_data/tripeptide-md/97.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b05cf5b000c87f5f9297d33fbbaa602451789583adbf87f1334896c769e71d06
-size 92303

--- a/tests/test_data/tripeptide-md/98.dat
+++ b/tests/test_data/tripeptide-md/98.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d7bfea3a98f03e976acdc12b87ddf8c8438a51ec34673bc6c44f7cac2e376f5
-size 92303

--- a/tests/test_data/tripeptide-md/99.dat
+++ b/tests/test_data/tripeptide-md/99.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57ecb3263718d1a7a290d2e6a227209d13a64f844b6974a68428ea6a034a53be
-size 92303

--- a/tools/generate-unit-test-expect/nist-dataset/result.json
+++ b/tools/generate-unit-test-expect/nist-dataset/result.json
@@ -1,0 +1,1 @@
+../../../download/nist.json

--- a/tools/generate-unit-test-expect/nist-dataset/result.json
+++ b/tools/generate-unit-test-expect/nist-dataset/result.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a1ed587eee3498e1c5005d45f70df3eb106851bbad28ed18d4b5f79900723f9
-size 22238056


### PR DESCRIPTION
Because git-lfs is costing large bandwidth, and lead to confusions to some users.
Removed files will be hosted in a separate server.
cc: @isayev 