### PR TITLE
Update README.md installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install torch -f https://download.pytorch.org/whl/nightly/cu100/torch.html
 If you updated TorchANI, you may also need to update PyTorch:
 
 ```bash
-pip install --upgrade torch_nightly -f https://download.pytorch.org/whl/nightly/cu100/torch.html
+pip install --upgrade torch -f https://download.pytorch.org/whl/nightly/cu100/torch.html
 ```
 
 After installing the correct PyTorch, you can install TorchANI by:

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ TorchANI is a pytorch implementation of ANI. It is currently under alpha release
 TorchANI requires the latest preview version of PyTorch. You can install PyTorch by the following commands (assuming cuda10):
 
 ```bash
-pip install numpy torchvision_nightly
-pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html
+pip install numpy
+pip install torch -f https://download.pytorch.org/whl/nightly/cu100/torch.html
 ```
 
 If you updated TorchANI, you may also need to update PyTorch:
 
 ```bash
-pip install --upgrade torch_nightly -f https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html
+pip install --upgrade torch_nightly -f https://download.pytorch.org/whl/nightly/cu100/torch.html
 ```
 
 After installing the correct PyTorch, you can install TorchANI by:


### PR DESCRIPTION
update installation according to https://pytorch.org

BTW, using this latest pip way, torch-nightly installed is called `torch`, not `torch-nightly`.
```
# packages in environment at /home/richard/program/anaconda3/envs/trial:
numpy                     1.17.0                   pypi_0    pypi
torch                     1.2.0                    pypi_0    pypi
```
using the conda way from https://pytorch.org, torch-nightly installed is called `pytorch`, still not `torch-nightly`.
```bash
conda install pytorch cudatoolkit=10.0 -c pytorch-nightly
```
```
pytorch                   1.3.0.dev20190819 py3.6_cuda10.0.130_cudnn7.6.2_0    pytorch-nightly
```

Which means that `pip install torchani` will never work.

So we should change 
```
    'install_requires': [
        'torch-nightly',
        'lark-parser',
    ],
```
to 
```
    'install_requires': [
        'torch',
        'lark-parser',
    ],
```
![](https://yyrcd-1256568788.cos.na-siliconvalley.myqcloud.com/yyrcd/2019-08-20-014900.png)


