### PR TITLE
New Dataset API add other properties

### DIFF
--- a/tests/test_data_new.py
+++ b/tests/test_data_new.py
@@ -42,6 +42,7 @@ class TestShuffledData(unittest.TestCase):
         print('=> checking tensor shape')
         print('the first batch is ([chunk1, chunk2, ...], {"energies", "force", ...}) in which chunk1=(species, coordinates)')
         batch_len = 0
+        print('1. chunks')
         for i, chunk in enumerate(self.chunks):
             print('chunk{}'.format(i + 1), 'species:', list(chunk[0].size()), chunk[0].dtype,
                   'coordinates:', list(chunk[1].size()), chunk[1].dtype)
@@ -52,12 +53,15 @@ class TestShuffledData(unittest.TestCase):
             self.assertEqual(chunk[1].shape[2], 3)
             self.assertEqual(chunk[1].shape[:2], chunk[0].shape[:2])
             batch_len += chunk[0].shape[0]
-
-        for key, value in self.properties.items():
-            print(key, list(value.size()), value.dtype)
-            self.assertEqual(value.dtype, torch.float32)
-            self.assertEqual(len(value.shape), 1)
-            self.assertEqual(value.shape[0], batch_len)
+        print('2. properties')
+        for i, key in enumerate(other_properties['properties']):
+            print(key, list(self.properties[key].size()), self.properties[key].dtype)
+            # check dtype
+            self.assertEqual(self.properties[key].dtype, other_properties['dtypes'][i])
+            # shape[0] == batch_size
+            self.assertEqual(self.properties[key].shape[0], other_properties['padded_shapes'][i][0])
+            # check len(shape)
+            self.assertEqual(len(self.properties[key].shape), len(other_properties['padded_shapes'][i]))
 
     def testLoadDataset(self):
         print('=> test loading all dataset')

--- a/tests/test_data_new.py
+++ b/tests/test_data_new.py
@@ -32,6 +32,7 @@ class TestFindThreshold(unittest.TestCase):
 
 
 class TestShuffledData(unittest.TestCase):
+
     def setUp(self):
         print('.. setup shuffle dataset')
         self.ds = torchani.data.ShuffledDataset(dspath, batch_size=batch_size, chunk_threshold=chunk_threshold, num_workers=2)

--- a/tests/test_data_new.py
+++ b/tests/test_data_new.py
@@ -35,7 +35,9 @@ class TestShuffledData(unittest.TestCase):
 
     def setUp(self):
         print('.. setup shuffle dataset')
-        self.ds = torchani.data.ShuffledDataset(dspath, batch_size=batch_size, chunk_threshold=chunk_threshold, num_workers=2,
+        self.ds = torchani.data.ShuffledDataset(dspath, batch_size=batch_size,
+                                                chunk_threshold=chunk_threshold,
+                                                num_workers=2,
                                                 other_properties=other_properties,
                                                 subtract_self_energies=True)
         self.chunks, self.properties = iter(self.ds).next()

--- a/tests/test_data_new.py
+++ b/tests/test_data_new.py
@@ -35,7 +35,9 @@ class TestShuffledData(unittest.TestCase):
 
     def setUp(self):
         print('.. setup shuffle dataset')
-        self.ds = torchani.data.ShuffledDataset(dspath, batch_size=batch_size, chunk_threshold=chunk_threshold, num_workers=2)
+        self.ds = torchani.data.ShuffledDataset(dspath, batch_size=batch_size, chunk_threshold=chunk_threshold, num_workers=2,
+                                                other_properties=other_properties,
+                                                subtract_self_energies=True)
         self.chunks, self.properties = iter(self.ds).next()
 
     def testTensorShape(self):

--- a/tests/test_data_new.py
+++ b/tests/test_data_new.py
@@ -6,7 +6,6 @@ import os
 
 path = os.path.dirname(os.path.realpath(__file__))
 dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s03.h5')
-# dspath = '/home/richard/dev/torchani/download/dataset/ani-1x/ANI-1x_dipole.h5'
 
 batch_size = 2560
 chunk_threshold = 5
@@ -24,8 +23,7 @@ other_properties = {'properties': ['energies'],
                     }
 
 
-# class TestFindThreshold(unittest.TestCase):
-class TestFindThreshold():
+class TestFindThreshold(unittest.TestCase):
     def setUp(self):
         print('.. check find threshold to split chunks')
 
@@ -33,8 +31,7 @@ class TestFindThreshold():
         torchani.data.find_threshold(dspath, batch_size=batch_size, threshold_max=10)
 
 
-# class TestShuffledData(unittest.TestCase):
-class TestShuffledData():
+class TestShuffledData(unittest.TestCase):
     def setUp(self):
         print('.. setup shuffle dataset')
         self.ds = torchani.data.ShuffledDataset(dspath, batch_size=batch_size, chunk_threshold=chunk_threshold, num_workers=2)

--- a/tools/training-benchmark.py
+++ b/tools/training-benchmark.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
                 predicted_energies.append(chunk_energies)
 
             num_atoms = torch.cat(num_atoms)
-            predicted_energies = torch.cat(predicted_energies)
+            predicted_energies = torch.cat(predicted_energies).to(true_energies.dtype)
             loss = (mse(predicted_energies, true_energies) / num_atoms.sqrt()).mean()
             rmse = hartree2kcal((mse(predicted_energies, true_energies)).mean()).detach().cpu().numpy()
             loss.backward()

--- a/torchani/data/new.py
+++ b/torchani/data/new.py
@@ -73,28 +73,7 @@ class CachedDataset(torch.utils.data.Dataset):
         self.properties = {}
         self.properties_info = properties_except_energy
 
-        # if user does not provide energies info
-        if 'properties' in self.properties_info and 'energies' not in self.properties_info['properties']:
-            # setup energies info, so the user does not need to input energies
-            self.properties_info['properties'].append('energies')
-            self.properties_info['padding_values'].append(False)
-            self.properties_info['padded_shapes'].append((batch_size))
-            self.properties_info['dtype'].append(torch.float64)
-        # if no properties provided
-        if 'properties' not in self.properties_info:
-            self.properties_info = {'properties': ['energies'],
-                                    'padding_values': [False],
-                                    'padded_shapes': [(batch_size, )],
-                                    'dtype': [torch.float64],
-                                    }
-        # print properties information
-        print('... The following properties will be loaded:')
-        for i, prop in enumerate(self.properties_info['properties']):
-            self.properties[prop] = []
-            message = '{}: (dtype: {}, padding_value: {}, padded_shape: {})'
-            print(message.format(prop, self.properties_info['dtype'][i],
-                                    self.properties_info['padding_values'][i],
-                                    self.properties_info['padded_shapes'][i]))
+        self.add_energies_to_properties_and_check()
 
         # anidataloader
         anidata = anidataloader(file_path)
@@ -247,6 +226,30 @@ class CachedDataset(torch.utils.data.Dataset):
         for i, _ in enumerate(self):
             if self.enable_pkbar:
                 pbar.update(i)
+
+    def add_energies_to_properties_and_check(self):
+        # if user does not provide energies info
+        if 'properties' in self.properties_info and 'energies' not in self.properties_info['properties']:
+            # setup energies info, so the user does not need to input energies
+            self.properties_info['properties'].append('energies')
+            self.properties_info['padding_values'].append(False)
+            self.properties_info['padded_shapes'].append((batch_size))
+            self.properties_info['dtype'].append(torch.float64)
+        # if no properties provided
+        if 'properties' not in self.properties_info:
+            self.properties_info = {'properties': ['energies'],
+                                    'padding_values': [False],
+                                    'padded_shapes': [(batch_size, )],
+                                    'dtype': [torch.float64],
+                                    }
+        # print properties information
+        print('... The following properties will be loaded:')
+        for i, prop in enumerate(self.properties_info['properties']):
+            self.properties[prop] = []
+            message = '{}: (dtype: {}, padding_value: {}, padded_shape: {})'
+            print(message.format(prop, self.properties_info['dtype'][i],
+                                    self.properties_info['padding_values'][i],
+                                    self.properties_info['padded_shapes'][i]))
 
     @staticmethod
     def sort_list_with_index(inputs, index):

--- a/torchani/data/new.py
+++ b/torchani/data/new.py
@@ -96,8 +96,7 @@ class CachedDataset(torch.utils.data.Dataset):
                 self_energies = np.array(sum([self_energies_dict[x] for x in molecule['species']]))
                 data_self_energies += list(np.tile(self_energies, (num_conformations, 1)))
             # other properties
-            for key, value in self.data_properties.items():
-                # print(key, molecule[key].dtype, molecule[key].shape,)
+            for key in self.data_properties:
                 self.data_properties[key] += list(molecule[key].reshape(num_conformations, -1))
             # pkbar update
             if self.enable_pkbar:

--- a/torchani/data/new.py
+++ b/torchani/data/new.py
@@ -232,7 +232,7 @@ class CachedDataset(torch.utils.data.Dataset):
             # setup energies info, so the user does not need to input energies
             self.properties_info['properties'].append('energies')
             self.properties_info['padding_values'].append(None)
-            self.properties_info['padded_shapes'].append((self.batch_size))
+            self.properties_info['padded_shapes'].append((self.batch_size, ))
             self.properties_info['dtypes'].append(torch.float64)
         # if no properties provided
         if 'properties' not in self.properties_info:

--- a/torchani/data/new.py
+++ b/torchani/data/new.py
@@ -67,6 +67,7 @@ class CachedDataset(torch.utils.data.Dataset):
             species_dict[s] = i
             self_energies_dict[s] = self_energies[i]
 
+        self.batch_size = batch_size
         self.data_species = []
         self.data_coordinates = []
         data_self_energies = []
@@ -108,7 +109,6 @@ class CachedDataset(torch.utils.data.Dataset):
             del data_self_energies
             gc.collect()
 
-        self.batch_size = batch_size
         self.length = (len(self.data_species) + self.batch_size - 1) // self.batch_size
         self.device = device
         self.shuffled_index = np.arange(len(self.data_species))
@@ -233,14 +233,14 @@ class CachedDataset(torch.utils.data.Dataset):
             # setup energies info, so the user does not need to input energies
             self.properties_info['properties'].append('energies')
             self.properties_info['padding_values'].append(None)
-            self.properties_info['padded_shapes'].append((batch_size))
+            self.properties_info['padded_shapes'].append((self.batch_size))
             self.properties_info['dtypes'].append(torch.float64)
         # if no properties provided
         if 'properties' not in self.properties_info:
             self.properties_info = {'properties': ['energies'],
                                     'padding_values': [None],
-                                    'padded_shapes': [(batch_size, )],
-                                    'dtype': [torch.float64],
+                                    'padded_shapes': [(self.batch_size, )],
+                                    'dtypes': [torch.float64],
                                     }
         # print properties information
         print('... The following properties will be loaded:')
@@ -248,8 +248,8 @@ class CachedDataset(torch.utils.data.Dataset):
             self.data_properties[prop] = []
             message = '{}: (dtype: {}, padding_value: {}, padded_shape: {})'
             print(message.format(prop, self.properties_info['dtypes'][i],
-                                    self.properties_info['padding_values'][i],
-                                    self.properties_info['padded_shapes'][i]))
+                                 self.properties_info['padding_values'][i],
+                                 self.properties_info['padded_shapes'][i]))
 
     @staticmethod
     def sort_list_with_index(inputs, index):

--- a/torchani/data/new.py
+++ b/torchani/data/new.py
@@ -348,6 +348,20 @@ def ShuffledDataset(file_path,
         shuffle (bool): whether to shuffle.
         chunk_threshold (int): threshould to split batch into chunks. Set to ``None`` will not split chunks.
             Use ``torchani.data.find_threshold`` to find resonable ``chunk_threshold``.
+        other_properties (dict): A dict which is used to extract properties other than
+            ``energies`` from dataset with correct padding, shape and dtype.\n
+            The example below will extract ``dipoles`` and ``forces``.\n
+            ``padding_values``: set to ``None`` means there is no need to pad for this property.
+
+            .. code-block:: python
+
+                other_properties = {'properties': ['dipoles', 'forces'],
+                                    'padding_values': [None, 0],
+                                    'padded_shapes': [(batch_size, 3), (batch_size, -1, 3)],
+                                    'dtypes': [torch.float32, torch.float32]
+                                    }
+
+        include_energies (bool): Whether include energies into properties. Default is ``True``.
         validation_split (float): Float between 0 and 1. Fraction of the dataset to be used
             as validation data.
         species_order (list): a list which specify how species are transfomed to int.

--- a/torchani/data/new.py
+++ b/torchani/data/new.py
@@ -189,15 +189,18 @@ class CachedDataset(torch.utils.data.Dataset):
         # properties
         properties = {}
         for i, key in enumerate(self.properties_info['properties']):
+            # get a batch of property
             prop = [self.properties[key][i] for i in batch_indices_shuffled]
+            # sort with number of atoms
             prop = self.sort_list_with_index(prop, sorted_atoms_idx.numpy())
+            # padding and convert to tensor
             if self.properties_info['padding_values'][i] is False:
                 prop = self.pad_and_convert_to_tensor([prop], no_padding=True)[0]
             else:
                 prop = self.pad_and_convert_to_tensor([prop], padding_value=self.properties_info['padding_values'][i])[0]
+            # set property shape and dtype
             padded_shape = list(self.properties_info['padded_shapes'][i])
-            # the last batch may does not have one batch data
-            padded_shape[0] = prop.shape[0]
+            padded_shape[0] = prop.shape[0]  # the last batch may does not have one batch data
             properties[key] = prop.reshape(padded_shape).to(self.properties_info['dtype'][i])
 
         # return: [chunk1, chunk2, ...], {"energies", "force", ...} in which chunk1=(species, coordinates)
@@ -364,7 +367,7 @@ def ShuffledDataset(file_path,
 
     val_data_loader = torch.utils.data.DataLoader(dataset=val_dataset,
                                                   batch_size=batch_size,
-                                                  shuffle=shuffle,
+                                                  shuffle=False,
                                                   num_workers=num_workers,
                                                   pin_memory=False,
                                                   collate_fn=my_collate_fn)


### PR DESCRIPTION
- other_properties (dict): A dict which is used to extract properties other than `energies` from dataset with correct padding, shape and dtype.
The example below will extract `dipoles` and `forces`.
  - `padding_values`: set to `None` means there is no need to pad for this property.
```python
other_properties = {'properties': ['dipoles', 'forces'],
                    'padding_values': [None, 0],
                    'padded_shapes': [(batch_size, 3), (batch_size, -1, 3)],
                    'dtypes': [torch.float32, torch.float32]
                    }
```
- include_energies (bool): Whether include `energies` into properties. Default is `True`.