### PR TITLE
Keep in-progress jobs once a test fails in Actions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,9 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7]
-        fail-fast: false
         test-filenames: [test_aev.py, test_aev_benzene_md.py, test_aev_nist.py, test_aev_tripeptide_md.py, test_data_new.py, test_ignite.py, test_utils.py, test_ase.py, test_energies.py, test_neurochem.py, test_vibrational.py, test_ensemble.py, test_padding.py, test_data.py, test_forces.py, test_structure_optim.py]
 
     steps:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
+        fail-fast: False
         test-filenames: [test_aev.py, test_aev_benzene_md.py, test_aev_nist.py, test_aev_tripeptide_md.py, test_data_new.py, test_ignite.py, test_utils.py, test_ase.py, test_energies.py, test_neurochem.py, test_vibrational.py, test_ensemble.py, test_padding.py, test_data.py, test_forces.py, test_structure_optim.py]
 
     steps:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        fail-fast: False
+        fail-fast: false
         test-filenames: [test_aev.py, test_aev_benzene_md.py, test_aev_nist.py, test_aev_tripeptide_md.py, test_data_new.py, test_ignite.py, test_utils.py, test_ase.py, test_energies.py, test_neurochem.py, test_vibrational.py, test_ensemble.py, test_padding.py, test_data.py, test_forces.py, test_structure_optim.py]
 
     steps:


### PR DESCRIPTION
By default, GitHub cancels all in-progress jobs if any `matrix` jobs fail in Actions. This PR will change the default to let all the tests running in case one of them fails.