### PR TITLE
Add force to unittest of JIT

### DIFF
--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -67,5 +67,12 @@ class TestForce(unittest.TestCase):
             self.assertLess(max_diff, self.tolerance)
 
 
+class TestForceJIT(TestForce):
+
+    def setUp(self):
+        super().setUp()
+        self.model = torch.jit.script(self.model)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
JIT uses symbolic differentiation (autodiff), which is different from autograd. Autodiff might be buggy, we need to make sure no bugs in autodiff influence TorchANI.