### PR TITLE
Trigger Actions on pull_request instead of push

### DIFF
--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -1,6 +1,6 @@
 name: deploy-test-pypi
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: docs
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,6 +1,6 @@
 name: flake8
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/python2.yml
+++ b/.github/workflows/python2.yml
@@ -1,6 +1,6 @@
 name: python2
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/runnable_submodules.yml
+++ b/.github/workflows/runnable_submodules.yml
@@ -1,6 +1,6 @@
 name: runnable submodules
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,6 +1,6 @@
 name: tools
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,6 +1,6 @@
 name: unit tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
We need to trigger the GitHub Actions on `pull_request` instead of `push`

>  [When a pull request is submitted from a forked repository to the base repository, GitHub sends the `pull_request` event to the base repository and no pull request events occur on the forked repository](https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories).
