### PR TITLE
Fix CUDA support in AEVComputer

### DIFF
--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -339,7 +339,7 @@ class AEVComputer(torch.nn.Module):
         self.Rcr = Rcr
         self.Rca = Rca
         assert Rca <= Rcr, "Current implementation of AEVComputer assumes Rca <= Rcr"
-        z# convert constant tensors to a ready-to-broadcast shape
+        # convert constant tensors to a ready-to-broadcast shape
         # shape convension (..., EtaR, ShfR)
         self.register_buffer('EtaR', EtaR.view(-1, 1))
         self.register_buffer('ShfR', ShfR.view(1, -1))

--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -339,7 +339,7 @@ class AEVComputer(torch.nn.Module):
         self.Rcr = Rcr
         self.Rca = Rca
         assert Rca <= Rcr, "Current implementation of AEVComputer assumes Rca <= Rcr"
-        # convert constant tensors to a ready-to-broadcast shape
+        z# convert constant tensors to a ready-to-broadcast shape
         # shape convension (..., EtaR, ShfR)
         self.register_buffer('EtaR', EtaR.view(-1, 1))
         self.register_buffer('ShfR', ShfR.view(1, -1))
@@ -362,7 +362,7 @@ class AEVComputer(torch.nn.Module):
         self.aev_length = self.radial_length + self.angular_length
         self.sizes = self.num_species, self.radial_sublength, self.radial_length, self.angular_sublength, self.angular_length, self.aev_length
 
-        self.register_buffer('triu_index', triu_index(num_species))
+        self.register_buffer('triu_index', triu_index(num_species).to(device=self.EtaR.device))
 
         # Set up default cell and compute default shifts.
         # These values are used when cell and pbc switch are not given.


### PR DESCRIPTION
`triu_index` is using `cpu`. Now casting the results to cuda device if needed.