### PR TITLE
Use modern type annotations for models.py

### DIFF
--- a/torchani/models.py
+++ b/torchani/models.py
@@ -28,6 +28,7 @@ shouldn't be used anymore.
 """
 
 import torch
+from torch import Tensor
 from typing import Tuple
 from pkg_resources import resource_filename
 from . import neurochem
@@ -88,8 +89,7 @@ class BuiltinNet(torch.nn.Module):
         self.neural_networks = neurochem.load_model_ensemble(
             self.species, self.ensemble_prefix, self.ensemble_size)
 
-    def forward(self, species_coordinates):
-        # type: (Tuple[torch.Tensor, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]
+    def forward(self, species_coordinates: Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]:
         """Calculates predicted properties for minibatch of configurations
 
         Args:


### PR DESCRIPTION
Specifying type inside a comment is stupid and should be removed