### PR TITLE
Subclass ModuleList to simplify code

### DIFF
--- a/torchani/nn.py
+++ b/torchani/nn.py
@@ -8,7 +8,7 @@ class SpeciesEnergies(NamedTuple):
     energies: Tensor
 
 
-class ANIModel(torch.nn.Module):
+class ANIModel(torch.nn.ModuleList):
     """ANI model that compute properties from species and AEVs.
 
     Different atom types might have different modules, when computing
@@ -25,11 +25,7 @@ class ANIModel(torch.nn.Module):
     """
 
     def __init__(self, modules):
-        super(ANIModel, self).__init__()
-        self.module_list = torch.nn.ModuleList(modules)
-
-    def __getitem__(self, i):
-        return self.module_list[i]
+        super(ANIModel, self).__init__(modules)
 
     def forward(self, species_aev: Tuple[Tensor, Tensor]) -> SpeciesEnergies:
         species, aev = species_aev
@@ -38,7 +34,7 @@ class ANIModel(torch.nn.Module):
 
         output = aev.new_zeros(species_.shape)
 
-        for i, m in enumerate(self.module_list):
+        for i, m in enumerate(self):
             mask = (species_ == i)
             midx = mask.nonzero().flatten()
             if midx.shape[0] > 0:
@@ -48,34 +44,29 @@ class ANIModel(torch.nn.Module):
         return SpeciesEnergies(species, torch.sum(output, dim=1))
 
 
-class Ensemble(torch.nn.Module):
+class Ensemble(torch.nn.ModuleList):
     """Compute the average output of an ensemble of modules."""
 
     def __init__(self, modules):
-        super(Ensemble, self).__init__()
-        self.modules_list = torch.nn.ModuleList(modules)
-        self.size = len(self.modules_list)
+        super(Ensemble, self).__init__(modules)
+        self.size = len(modules)
 
     def forward(self, species_input: Tuple[Tensor, Tensor]) -> SpeciesEnergies:
         sum_ = 0
-        for x in self.modules_list:
+        for x in self:
             sum_ += x(species_input)[1]
         species, _ = species_input
         return SpeciesEnergies(species, sum_ / self.size)
 
-    def __getitem__(self, i):
-        return self.modules_list[i]
 
-
-class Sequential(torch.nn.Module):
+class Sequential(torch.nn.ModuleList):
     """Modified Sequential module that accept Tuple type as input"""
 
     def __init__(self, *modules):
-        super(Sequential, self).__init__()
-        self.modules_list = torch.nn.ModuleList(modules)
+        super(Sequential, self).__init__(modules)
 
     def forward(self, input_: Tuple[Tensor, Tensor]):
-        for module in self.modules_list:
+        for module in self:
             input_ = module(input_)
         return input_
 


### PR DESCRIPTION
Subclassing was the way things were implemented, but when we add JIT support, we have to change it to be JIT-compatible. Now https://github.com/pytorch/pytorch/pull/28988 is coming soon and it's time to bring the original implementation back.