### PR TITLE
Fix failure on forked repository

### DIFF
--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -29,6 +29,7 @@ jobs:
         pip install twine wheel
     - name: Deploy
       run: |
+        echo $GITHUB_REF
         rm -rf dist/*
         git tag $(date +'v%Y.%m.%d.%H.%M.%S')
         python setup.py bdist bdist_wheel

--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -29,7 +29,7 @@ jobs:
         pip install twine wheel
     - name: Deploy
       run: |
-        echo $GITHUB_HEAD_REF
+        [ ! -z "$GITHUB_HEAD_REF" ] && exit
         rm -rf dist/*
         git tag $(date +'v%Y.%m.%d.%H.%M.%S')
         python setup.py bdist bdist_wheel

--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -29,7 +29,7 @@ jobs:
         pip install twine wheel
     - name: Deploy
       run: |
-        echo $GITHUB_REF
+        echo $GITHUB_HEAD_REF
         rm -rf dist/*
         git tag $(date +'v%Y.%m.%d.%H.%M.%S')
         python setup.py bdist bdist_wheel

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         git config --global user.name "zasdfgbnm-bot"
     - name: Deploy
       run: |
-        echo $GITHUB_REF
+        [ ! -z "$GITHUB_HEAD_REF" ] && exit
         git clone git@github.com:aiqm/torchani-test-docs.git deploy_dir -b gh-pages
         rm -rf deploy_dir/*
         touch deploy_dir/.nojekyll

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
         git config --global user.name "zasdfgbnm-bot"
     - name: Deploy
       run: |
+        echo $GITHUB_REF
         git clone git@github.com:aiqm/torchani-test-docs.git deploy_dir -b gh-pages
         rm -rf deploy_dir/*
         touch deploy_dir/.nojekyll


### PR DESCRIPTION
GitHub secrets are not available on forked repositories, causing flaky failures on forked repositories, such as https://github.com/aiqm/torchani/pull/413 and https://github.com/aiqm/torchani/pull/393. I have force merged these PRs, but we need to skip these failing tests on forked repositories.

Reference: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables
```
GITHUB_HEAD_REF | Only set for forked repositories. The branch of the head repository.
```