### PR TITLE
ChemicalSymbolsToInts is being used wrong

### DIFF
--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -61,7 +61,7 @@ ShfA = torch.tensor([9.0000000e-01, 1.5500000e+00, 2.2000000e+00, 2.8500000e+00]
 num_species = 4
 aev_computer = torchani.AEVComputer(Rcr, Rca, EtaR, ShfR, EtaA, Zeta, ShfA, ShfZ, num_species)
 energy_shifter = torchani.utils.EnergyShifter(None)
-species_to_tensor = torchani.utils.ChemicalSymbolsToInts('HCNO')
+species_to_tensor = torchani.utils.ChemicalSymbolsToInts(['H', 'C', 'N', 'O'])
 
 ###############################################################################
 # Now let's setup datasets. These paths assumes the user run this script under

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -38,7 +38,7 @@ ShfA = torch.tensor([9.0000000e-01, 1.5500000e+00, 2.2000000e+00, 2.8500000e+00]
 num_species = 4
 aev_computer = torchani.AEVComputer(Rcr, Rca, EtaR, ShfR, EtaA, Zeta, ShfA, ShfZ, num_species)
 energy_shifter = torchani.utils.EnergyShifter(None)
-species_to_tensor = torchani.utils.ChemicalSymbolsToInts('HCNO')
+species_to_tensor = torchani.utils.ChemicalSymbolsToInts(['H', 'C', 'N', 'O'])
 
 
 try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import torchani
 class TestUtils(unittest.TestCase):
 
     def testChemicalSymbolsToInts(self):
-        str2i = torchani.utils.ChemicalSymbolsToInts('ABCDEF')
+        str2i = torchani.utils.ChemicalSymbolsToInts(['A', 'B', 'C', 'D', 'E', 'F'])
         self.assertEqual(len(str2i), 6)
         self.assertListEqual(str2i('BACCC').tolist(), [1, 0, 2, 2, 2])
 

--- a/tools/training-benchmark-nsys-profile.py
+++ b/tools/training-benchmark-nsys-profile.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         print('using original dataset API')
         print('=> loading dataset...')
         energy_shifter = torchani.utils.EnergyShifter(None)
-        species_to_tensor = torchani.utils.ChemicalSymbolsToInts('HCNO')
+        species_to_tensor = torchani.utils.ChemicalSymbolsToInts(['H', 'C', 'N', 'O'])
         dataset = torchani.data.load_ani_dataset(parser.dataset_path, species_to_tensor,
                                                  parser.batch_size, device=parser.device,
                                                  transform=[energy_shifter.subtract_from_dataset])

--- a/tools/training-benchmark.py
+++ b/tools/training-benchmark.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
         print('using original dataset API')
         print('=> loading dataset...')
         energy_shifter = torchani.utils.EnergyShifter(None)
-        species_to_tensor = torchani.utils.ChemicalSymbolsToInts('HCNO')
+        species_to_tensor = torchani.utils.ChemicalSymbolsToInts(['H', 'C', 'N', 'O'])
         dataset = torchani.data.load_ani_dataset(parser.dataset_path, species_to_tensor,
                                                  parser.batch_size, device=parser.device,
                                                  transform=[energy_shifter.subtract_from_dataset])

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -199,6 +199,14 @@ class EnergyShifter(torch.nn.Module):
 class ChemicalSymbolsToInts:
     """Helper that can be called to convert chemical symbol string to integers
 
+    .. warning::
+
+        If the input to the call is a string python will iterate over 
+        characters, this means that a string such as 'CHClFe' will be 
+        intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
+        input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'], 
+        and not a string.
+
     Arguments:
         all_species (:class:`collections.abc.Sequence` of :class:`str`):
             sequence of all supported species, in order.

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -221,11 +221,11 @@ class ChemicalSymbolsToInts:
 
     .. warning::
 
-        If the input to init is a string python will iterate over
+        If the input is a string python will iterate over
         characters, this means that a string such as 'CHClFe' will be
         intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
-        input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
-        and not a string. The output of this call does NOT correspond to a
+        input either a :class:`list` or a :class:`numpy.ndarray` ['C', 'H', 'Cl', 'Fe'],
+        and not a string. The output of a call does NOT correspond to a
         tensor of atomic numbers.
 
     Arguments:

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -197,7 +197,27 @@ class EnergyShifter(torch.nn.Module):
 
 
 class ChemicalSymbolsToInts:
-    """Helper that can be called to convert chemical symbol string to integers
+    r"""Helper that can be called to convert chemical symbol string to integers
+
+    On initialization the class should be supplied with a :class:`list` (or in
+    general :class:`collections.abc.Sequence`) of :class:`str`. The returned
+    instance is a callable object, which can be called with an arbitrary list
+    of the supported species that is converted into a tensor of dtype
+    :class:`torch.long`. Usage example:
+
+    .. code-block:: python
+
+       from torchani.utils import ChemicalSymbolsToInts
+       
+
+       # We initialize ChemicalSymbolsToInts with the supported species
+       species_to_tensor = ChemicalSymbolsToInts(['H', 'C', 'Fe', 'Cl'])
+
+       # We have a species list which we want to convert to an index tensor
+       index_tensor = species_to_tensor(['H', 'C', 'H', 'H', 'C', 'Cl', 'Fe'])
+
+       # index_tensor is now [0 1 0 0 1 3 2]
+
 
     .. warning::
 
@@ -205,7 +225,8 @@ class ChemicalSymbolsToInts:
         characters, this means that a string such as 'CHClFe' will be
         intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
         input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
-        and not a string.
+        and not a string. The output of this call does NOT correspond to a
+        tensor of atomic numbers.
 
     Arguments:
         all_species (:class:`collections.abc.Sequence` of :class:`str`):
@@ -216,24 +237,7 @@ class ChemicalSymbolsToInts:
         self.rev_species = {s: i for i, s in enumerate(all_species)}
 
     def __call__(self, species):
-        """Convert species from sequence of strings to 1D tensor
-
-        .. warning::
-
-            If the input to init is a string python will iterate over
-            characters, this means that a string such as 'CHClFe' will be
-            intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
-            input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
-            and not a string. The output of this call does NOT correspond to a
-            tensor of atomic numbers.
-
-        Arguments:
-            species (:class:`collections.abc.Sequence` of :class:`str`):
-                sequence of species
-        Returns:
-            :class:`torch.Tensor`
-                A tensor of dtype torch.long with indices
-        """
+        r"""Convert species from sequence of strings to 1D tensor"""
         rev = [self.rev_species[s] for s in species]
         return torch.tensor(rev, dtype=torch.long)
 

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -208,7 +208,7 @@ class ChemicalSymbolsToInts:
     .. code-block:: python
 
        from torchani.utils import ChemicalSymbolsToInts
-       
+
 
        # We initialize ChemicalSymbolsToInts with the supported species
        species_to_tensor = ChemicalSymbolsToInts(['H', 'C', 'Fe', 'Cl'])

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -201,10 +201,10 @@ class ChemicalSymbolsToInts:
 
     .. warning::
 
-        If the input to the call is a string python will iterate over 
-        characters, this means that a string such as 'CHClFe' will be 
+        If the input to the call is a string python will iterate over
+        characters, this means that a string such as 'CHClFe' will be
         intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
-        input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'], 
+        input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
         and not a string.
 
     Arguments:

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -201,7 +201,7 @@ class ChemicalSymbolsToInts:
 
     .. warning::
 
-        If the input to the call is a string python will iterate over
+        If the input to init is a string python will iterate over
         characters, this means that a string such as 'CHClFe' will be
         intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
         input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
@@ -216,7 +216,23 @@ class ChemicalSymbolsToInts:
         self.rev_species = {s: i for i, s in enumerate(all_species)}
 
     def __call__(self, species):
-        """Convert species from squence of strings to 1D tensor"""
+        """Convert species from squence of strings to 1D tensor
+
+        .. warning::
+
+            If the input to init is a string python will iterate over
+            characters, this means that a string such as 'CHClFe' will be
+            intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
+            input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
+            and not a string.
+
+        Arguments:
+            species (:class:`collections.abc.Sequence` of :class:`str`):
+                sequence of species
+        Returns:
+            :class:`torch.Tensor`
+                A tensor of dtype torch.long with indices
+        """
         rev = [self.rev_species[s] for s in species]
         return torch.tensor(rev, dtype=torch.long)
 

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -216,7 +216,7 @@ class ChemicalSymbolsToInts:
         self.rev_species = {s: i for i, s in enumerate(all_species)}
 
     def __call__(self, species):
-        """Convert species from squence of strings to 1D tensor
+        """Convert species from sequence of strings to 1D tensor
 
         .. warning::
 
@@ -224,7 +224,8 @@ class ChemicalSymbolsToInts:
             characters, this means that a string such as 'CHClFe' will be
             intepreted as 'C' 'H' 'C' 'l' 'F' 'e'. It is recommended that you
             input either a list or a numpy.ndarray ['C', 'H', 'Cl', 'Fe'],
-            and not a string.
+            and not a string. The output of this call does NOT correspond to a
+            tensor of atomic numbers.
 
         Arguments:
             species (:class:`collections.abc.Sequence` of :class:`str`):


### PR DESCRIPTION
We came to know that some people had bugs in their code because they input strings like 'CHNClFeCu' into ChemicalSymbolsToInts instead of ['C', 'H', 'N', 'Cl', 'Fe', 'Cu']. This PR adds a warning to ChemicalSymbolsToInts and changes ocurrences of ['CHNO'] to ['C', 'H', 'N', 'O'] in the code, to encourage safer use of the class.