### PR TITLE
Improve more on new dataset API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dist
 *.zip
 Untitled.ipynb
 /nnp_training.py
+/test*.py

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist
 *.qdstrm
 *.zip
 Untitled.ipynb
+/nnp_training.py

--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -82,9 +82,7 @@ except NameError:
 dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 batch_size = 2560
 
-dataset = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle()
-size = len(dataset)
-training, validation = dataset.split(int(0.8 * size), None)
+training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 print('Self atomic energies: ', energy_shifter.self_energies)

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -49,9 +49,7 @@ dspath = os.path.join(path, '../dataset/ani-1x/sample.h5')
 
 batch_size = 2560
 
-dataset = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle()
-size = len(dataset)
-training, validation = dataset.split(int(0.8 * size), None)
+training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,7 +3,7 @@ import torchani
 import unittest
 
 path = os.path.dirname(os.path.realpath(__file__))
-dataset_path = os.path.join(path, 'dataset/ani-1x/sample.h5')
+dataset_path = os.path.join(path, '../dataset/ani-1x/sample.h5')
 batch_size = 256
 ani1x = torchani.models.ANI1x()
 consts = ani1x.consts

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -34,6 +34,70 @@ class TestData(unittest.TestCase):
             non_padding = (species >= 0)[:, -1].nonzero()
             self.assertGreater(non_padding.numel(), 0)
 
+    def testReEnter(self):
+        ds = torchani.data.load(dataset_path)
+        for d in ds:
+            pass
+        entered = False
+        for d in ds:
+            entered = True
+        self.assertTrue(entered)
+
+        ds = ds.subtract_self_energies(sae_dict)
+        entered = False
+        for d in ds:
+            entered = True
+            pass
+        self.assertTrue(entered)
+        entered = False
+        for d in ds:
+            entered = True
+        self.assertTrue(entered)
+
+        ds = ds.species_to_indices()
+        entered = False
+        for d in ds:
+            entered = True
+            pass
+        self.assertTrue(entered)
+        entered = False
+        for d in ds:
+            entered = True
+        self.assertTrue(entered)
+
+        ds = ds.shuffle()
+        entered = False
+        for d in ds:
+            entered = True
+            pass
+        self.assertTrue(entered)
+        entered = False
+        for d in ds:
+            entered = True
+        self.assertTrue(entered)
+
+        ds = ds.collate(batch_size)
+        entered = False
+        for d in ds:
+            entered = True
+            pass
+        self.assertTrue(entered)
+        entered = False
+        for d in ds:
+            entered = True
+        self.assertTrue(entered)
+
+        ds = ds.cache()
+        entered = False
+        for d in ds:
+            entered = True
+            pass
+        self.assertTrue(entered)
+        entered = False
+        for d in ds:
+            entered = True
+        self.assertTrue(entered)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 import os
+import torch
 import torchani
 import unittest
 
@@ -107,6 +108,13 @@ class TestData(unittest.TestCase):
         len(ds)
         ds = ds.collate(batch_size)
         len(ds)
+
+    def testDataloader(self):
+        shifter = torchani.EnergyShifter(None)
+        dataset = list(torchani.data.load(dataset_path).subtract_self_energies(shifter).species_to_indices().shuffle())
+        loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, collate_fn=torchani.data.collate_fn, num_workers=64)
+        for i in loader:
+            pass
 
 
 if __name__ == '__main__':

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -97,6 +97,17 @@ class TestData(unittest.TestCase):
             entered = True
         self.assertTrue(entered)
 
+    def testShapeInference(self):
+        shifter = torchani.EnergyShifter(None)
+        ds = torchani.data.load(dataset_path).subtract_self_energies(shifter)
+        len(ds)
+        ds = ds.species_to_indices()
+        len(ds)
+        ds = ds.shuffle()
+        len(ds)
+        ds = ds.collate(batch_size)
+        len(ds)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -35,6 +35,7 @@ class TestData(unittest.TestCase):
             self.assertGreater(non_padding.numel(), 0)
 
     def testReEnter(self):
+        # make sure that a dataset can be iterated multiple times
         ds = torchani.data.load(dataset_path)
         for d in ds:
             pass
@@ -47,7 +48,6 @@ class TestData(unittest.TestCase):
         entered = False
         for d in ds:
             entered = True
-            pass
         self.assertTrue(entered)
         entered = False
         for d in ds:
@@ -58,7 +58,6 @@ class TestData(unittest.TestCase):
         entered = False
         for d in ds:
             entered = True
-            pass
         self.assertTrue(entered)
         entered = False
         for d in ds:

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -78,6 +78,7 @@ class IterableAdapter:
     def __iter__(self):
         return iter(self.iterable_factory())
 
+
 class IterableAdapterWithLength(IterableAdapter):
 
     def __init__(self, iterable_factory, length):
@@ -96,13 +97,14 @@ class Transformations:
         if species_order == 'periodic_table':
             species_order = utils.PERIODIC_TABLE
         idx = {k: i for i, k in enumerate(species_order)}
+
         def reenterable_iterable_factory():
             for d in reenterable_iterable:
                 d['species'] = numpy.array([idx[s] for s in d['species']])
                 yield d
         try:
             return IterableAdapterWithLength(reenterable_iterable_factory, len(reenterable_iterable))
-        except:
+        except TypeError:
             return IterableAdapter(reenterable_iterable_factory)
 
     @staticmethod
@@ -142,6 +144,7 @@ class Transformations:
             for s, e in zip(species, sae_):
                 self_energies[s] = e
             shifter.__init__(sae, shifter.fit_intercept)
+
         def reenterable_iterable_factory():
             for d in reenterable_iterable:
                 e = intercept
@@ -204,7 +207,7 @@ class Transformations:
         try:
             length = (len(reenterable_iterable) + batch_size - 1) // batch_size
             return IterableAdapterWithLength(reenterable_iterable_factory, length)
-        except:
+        except TypeError:
             return IterableAdapter(reenterable_iterable_factory)
 
     @staticmethod
@@ -214,7 +217,7 @@ class Transformations:
                 yield {k: d[k].pin_memory() for k in d}
         try:
             return IterableAdapterWithLength(reenterable_iterable_factory, len(reenterable_iterable))
-        except:
+        except TypeError:
             return IterableAdapter(reenterable_iterable_factory)
 
 

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -8,11 +8,15 @@ from torchani.units import sqrt_mhessian2invcm, sqrt_mhessian2milliev, mhessian2
 from .nn import SpeciesEnergies
 
 
+def empty_list():
+    return []
+
+
 def stack_with_padding(properties, padding):
-    output = defaultdict(lambda: [])
+    output = defaultdict(empty_list)
     for p in properties:
         for k, v in p.items():
-            output[k].append(v)
+            output[k].append(torch.as_tensor(v))
     for k, v in output.items():
         if v[0].dim() == 0:
             output[k] = torch.stack(v)


### PR DESCRIPTION
The new suggested way to use dataset is:

```Python
training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
training = training.collate(batch_size).cache()
validation = validation.collate(batch_size).cache()
```
which is cleaner than the previous
```Python
dataset = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle()
size = len(dataset)
training, validation = dataset.split(int(0.8 * size), None)
training = training.collate(batch_size).cache()
validation = validation.collate(batch_size).cache()
```

The memory usage has reduced from the previous 18GB to 16GB, this is a small improvement, but it is hard to make it as good as the previously API by @yueyericardo because we are now not chunking, so we have to spend lots of memories to store padding.

If we don't want to use that much memory, we can remove the `.cache()` from the last two lines, but we now need a data loader to achieve comparable performance:

```python
training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
training = torch.utils.data.DataLoader(list(training), batch_size=batch_size, collate_fn=torchani.data.collate_fn, num_workers=64)
validation = torch.utils.data.DataLoader(list(validation), batch_size=batch_size, collate_fn=torchani.data.collate_fn, num_workers=64)
```

The above code uses ~9GB RAM