### PR TITLE
Show stable torch support status on PR

### DIFF
--- a/.github/workflows/stable-torch.yml
+++ b/.github/workflows/stable-torch.yml
@@ -1,6 +1,7 @@
 name: stable-torch
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -14,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Just for information. This does not mean we will support stable PyTorch and this check is allowed to fail.