### PR TITLE
Fix order of transformations in data loader

### DIFF
--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -82,7 +82,7 @@ except NameError:
 dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 batch_size = 2560
 
-training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
+training, validation = torchani.data.load(dspath).species_to_indices().subtract_self_energies(energy_shifter).shuffle().split(0.8, None)
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 print('Self atomic energies: ', energy_shifter.self_energies)

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -49,7 +49,7 @@ dspath = os.path.join(path, '../dataset/ani-1x/sample.h5')
 
 batch_size = 2560
 
-training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
+training, validation = torchani.data.load(dspath).species_to_indices().subtract_self_energies(energy_shifter).shuffle().split(0.8, None)
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -15,7 +15,7 @@ aev_computer = ani1x.aev_computer
 class TestData(unittest.TestCase):
 
     def testTensorShape(self):
-        ds = torchani.data.load(dataset_path).subtract_self_energies(sae_dict).species_to_indices().shuffle().collate(batch_size).cache()
+        ds = torchani.data.load(dataset_path).species_to_indices().subtract_self_energies(sae_dict).shuffle().collate(batch_size).cache()
         for d in ds:
             species = d['species']
             coordinates = d['coordinates']
@@ -29,7 +29,7 @@ class TestData(unittest.TestCase):
             self.assertEqual(coordinates.shape[0], energies.shape[0])
 
     def testNoUnnecessaryPadding(self):
-        ds = torchani.data.load(dataset_path).subtract_self_energies(sae_dict).species_to_indices().shuffle().collate(batch_size).cache()
+        ds = torchani.data.load(dataset_path).species_to_indices().subtract_self_energies(sae_dict).shuffle().collate(batch_size).cache()
         for d in ds:
             species = d['species']
             non_padding = (species >= 0)[:, -1].nonzero()
@@ -111,7 +111,7 @@ class TestData(unittest.TestCase):
 
     def testDataloader(self):
         shifter = torchani.EnergyShifter(None)
-        dataset = list(torchani.data.load(dataset_path).subtract_self_energies(shifter).species_to_indices().shuffle())
+        dataset = list(torchani.data.load(dataset_path).species_to_indices().subtract_self_energies(shifter).shuffle())
         loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, collate_fn=torchani.data.collate_fn, num_workers=64)
         for i in loader:
             pass

--- a/tests/test_jit_builtin_models.py
+++ b/tests/test_jit_builtin_models.py
@@ -19,7 +19,7 @@ class TestBuiltinModelsJIT(unittest.TestCase):
 
     def setUp(self):
         self.ani1ccx = torchani.models.ANI1ccx()
-        self.ds = torchani.data.load(dspath).subtract_self_energies(self.ani1ccx.sae_dict).species_to_indices().shuffle().collate(256).cache()
+        self.ds = torchani.data.load(dspath).species_to_indices().subtract_self_energies(self.ani1ccx.sae_dict).shuffle().collate(256).cache()
 
     def _test_model(self, model):
         properties = next(iter(self.ds))

--- a/tools/training-benchmark-nsys-profile.py
+++ b/tools/training-benchmark-nsys-profile.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
 
     print('=> loading dataset...')
     shifter = torchani.EnergyShifter(None)
-    dataset = list(torchani.data.load(parser.dataset_path).subtract_self_energies(shifter).species_to_indices().shuffle().collate(parser.batch_size))
+    dataset = list(torchani.data.load(parser.dataset_path).species_to_indices().subtract_self_energies(shifter).shuffle().collate(parser.batch_size))
 
     print('=> start warming up')
     total_batch_counter = 0

--- a/tools/training-benchmark.py
+++ b/tools/training-benchmark.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 
     print('=> loading dataset...')
     shifter = torchani.EnergyShifter(None)
-    dataset = list(torchani.data.load(parser.dataset_path).subtract_self_energies(shifter).species_to_indices().shuffle().collate(parser.batch_size))
+    dataset = list(torchani.data.load(parser.dataset_path).species_to_indices().subtract_self_energies(shifter).shuffle().collate(parser.batch_size))
 
     print('=> start training')
     start = time.time()

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -34,7 +34,7 @@ Example:
 .. code-block:: python
 
     energy_shifter = torchani.utils.EnergyShifter(None)
-    training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(int(0.8 * size), None)
+    training, validation = torchani.data.load(dspath).species_to_indices().subtract_self_energies(energy_shifter).shuffle().split(int(0.8 * size), None)
     training = training.collate(batch_size).cache()
     validation = validation.collate(batch_size).cache()
 
@@ -43,9 +43,13 @@ with multiprocessing to achieve comparable performance with less memory usage:
 
 .. code-block:: python
 
-    training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(0.8, None)
+    training, validation = torchani.data.load(dspath).species_to_indices().subtract_self_energies(energy_shifter).shuffle().split(0.8, None)
     training = torch.utils.data.DataLoader(list(training), batch_size=batch_size, collate_fn=torchani.data.collate_fn, num_workers=64)
     validation = torch.utils.data.DataLoader(list(validation), batch_size=batch_size, collate_fn=torchani.data.collate_fn, num_workers=64)
+
+.. warning::
+
+    The `species_to_indices` transformation must be applied prior to `subtract_self_energies`.
 """
 
 from os.path import join, isfile, isdir
@@ -104,7 +108,7 @@ class Transformations:
     """Convert one reenterable iterable to another reenterable iterable"""
 
     @staticmethod
-    def species_to_indices(reenterable_iterable, species_order=('H', 'C', 'N', 'O', 'F', 'Cl', 'S')):
+    def species_to_indices(reenterable_iterable, species_order=('H', 'C', 'N', 'O', 'F', 'S', 'Cl')):
         if species_order == 'periodic_table':
             species_order = utils.PERIODIC_TABLE
         idx = {k: i for i, k in enumerate(species_order)}

--- a/torchani/neurochem/__init__.py
+++ b/torchani/neurochem/__init__.py
@@ -557,8 +557,8 @@ if sys.version_info[0] > 2:
 
         def load_data(self, training_path, validation_path):
             """Load training and validation dataset from file."""
-            self.training_set = self.imports.load(training_path).subtract_self_energies(self.sae).species_to_indices().shuffle().collate(self.training_batch_size).cache()
-            self.validation_set = self.imports.load(validation_path).subtract_self_energies(self.sae).species_to_indices().shuffle().collate(self.validation_batch_size).cache()
+            self.training_set = self.imports.load(training_path).species_to_indices().subtract_self_energies(self.sae).shuffle().collate(self.training_batch_size).cache()
+            self.validation_set = self.imports.load(validation_path).species_to_indices().subtract_self_energies(self.sae).shuffle().collate(self.validation_batch_size).cache()
 
         def evaluate(self, dataset):
             """Run the evaluation"""


### PR DESCRIPTION
`species_to_indices` transformation should be applied before `subtract_self_energies`. Otherwise, the SAEs calculated in `subtract_self_energies` will be sorted based on species names (instead of indices), leading to incorrect assignment of SAEs.