### PR TITLE
Avoid loading/padding forces when not needed

### DIFF
--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -51,7 +51,7 @@ batch_size = 2560
 
 training, validation = torchani.data.load(
     dspath,
-    additional_properties=('dipoles',)
+    additional_properties=('forces',)
 ).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
 
 training = training.collate(batch_size).cache()

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -49,7 +49,11 @@ dspath = os.path.join(path, '../dataset/ani-1x/sample.h5')
 
 batch_size = 2560
 
-training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
+training, validation = torchani.data.load(
+    dspath,
+    additional_properties=('dipoles',)
+).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
+
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 

--- a/tests/test_jit_builtin_models.py
+++ b/tests/test_jit_builtin_models.py
@@ -6,13 +6,6 @@ import os
 
 path = os.path.dirname(os.path.realpath(__file__))
 dspath = os.path.join(path, '../dataset/ani-1x/sample.h5')
-batch_size = 256
-chunk_threshold = 5
-other_properties = {'properties': ['energies'],
-                    'padding_values': [None],
-                    'padded_shapes': [(batch_size, )],
-                    'dtypes': [torch.float64],
-                    }
 
 
 class TestBuiltinModelsJIT(unittest.TestCase):

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -67,7 +67,7 @@ if PKBAR_INSTALLED:
 verbose = True
 
 
-PROPERTIES = ('energies', 'forces')
+PROPERTIES = ('energies',)
 PADDING = {
     'species': -1,
     'coordinates': 0.0,


### PR DESCRIPTION
This will help to save ~4GB memory when loading ANI1x data for energy training. 