### PR TITLE
Add a function to recast all buffer tensors

### DIFF
--- a/torchani/models.py
+++ b/torchani/models.py
@@ -95,6 +95,11 @@ class BuiltinNet(torch.nn.Module):
         self.neural_networks = neurochem.load_model_ensemble(
             self.species, self.ensemble_prefix, self.ensemble_size)
 
+    @torch.jit.export                                                                                  
+    def _recast_long_buffers(self):                                                                           
+        self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)   
+        self.aev_computer.triu_index = self.aev_computer.triu_index.to(dtype=torch.long)
+
     def forward(self, species_coordinates: Tuple[Tensor, Tensor],
                 cell: Optional[Tensor] = None,
                 pbc: Optional[Tensor] = None) -> SpeciesEnergies:

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -95,9 +95,9 @@ class BuiltinNet(torch.nn.Module):
         self.neural_networks = neurochem.load_model_ensemble(
             self.species, self.ensemble_prefix, self.ensemble_size)
 
-    @torch.jit.export                                                                                  
-    def _recast_long_buffers(self):                                                                           
-        self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)   
+    @torch.jit.export
+    def _recast_long_buffers(self):
+        self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)
         self.aev_computer.triu_index = self.aev_computer.triu_index.to(dtype=torch.long)
 
     def forward(self, species_coordinates: Tuple[Tensor, Tensor],


### PR DESCRIPTION
When using the model in a C++ environment, ``model.to(torch::kDouble)`` converts all Parameters AND all buffers to double. As a consequence all torch.long buffers in the model are converted to torch.double, which we definitely don't want. 

After this it becomes a hassle to specifically convert named buffers into doubles, I didn't find anything in the C++ API that exposed a handle to a ``torch::jit::script::Module`` buffer, so the workaround is to add a function that recasts the torch.long buffers to double once again on the python side

I'm not sure if this is a feature or a bug of libtorch, but I think it differs from the python behaviour

Sorry for the long explanation but this is complex. 