### PR TITLE
Refactor builtinnet

### DIFF
--- a/tests/test_periodic_table_indexing.py
+++ b/tests/test_periodic_table_indexing.py
@@ -29,7 +29,7 @@ class TestSpeciesConverterJIT(TestSpeciesConverter):
         self.c = torch.jit.script(self.c)
 
 
-class TestBuiltinNetPeriodicTableIndex(unittest.TestCase):
+class TestBuiltinEnsemblePeriodicTableIndex(unittest.TestCase):
 
     def setUp(self):
         self.model1 = torchani.models.ANI1x()

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -38,7 +38,7 @@ from .aev import AEVComputer
 
 class BuiltinModel(torch.nn.Module):
     r"""Private template for the builtin ANI models """
-    def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, periodic_table_index):
+    def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, species, periodic_table_index):
         super(BuiltinModel, self).__init__()
         if periodic_table_index:
             self.species_converter = species_converter
@@ -48,6 +48,7 @@ class BuiltinModel(torch.nn.Module):
         self.neural_networks = neural_networks
         self.energy_shifter = energy_shifter
         self._species_to_tensor = species_to_tensor
+        self.species = species
         self.periodic_table_index = periodic_table_index
 
     @torch.jit.export
@@ -144,12 +145,13 @@ class BuiltinEnsemble(BuiltinModel):
     """
 
     def __init__(self, species_converter, aev_computer, neural_networks,
-                 energy_shifter, species_to_tensor, periodic_table_index):
+                 energy_shifter, species_to_tensor, species, periodic_table_index):
         super(BuiltinEnsemble, self).__init__(species_converter,
                                               aev_computer,
                                               neural_networks,
                                               energy_shifter,
                                               species_to_tensor,
+                                              species,
                                               periodic_table_index)
 
     @classmethod
@@ -182,7 +184,7 @@ class BuiltinEnsemble(BuiltinModel):
         species_to_tensor = consts.species_to_tensor
 
         return cls(species_converter, aev_computer, neural_networks,
-                   energy_shifter, species_to_tensor, periodic_table_index)
+                   energy_shifter, species_to_tensor, consts.species, periodic_table_index)
 
     def __getitem__(self, index):
         """Get a single 'AEVComputer -> ANIModel -> EnergyShifter' sequential model

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -36,8 +36,6 @@ from .nn import SpeciesConverter, SpeciesEnergies
 from .aev import AEVComputer
 
 
-
-
 class BuiltinModel(torch.nn.Module):
     r"""Private template for the builtin ANI models """
     def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, periodic_table_index):
@@ -108,7 +106,6 @@ class BuiltinModel(torch.nn.Module):
         return ase.Calculator(self.species, self, **kwargs)
 
 
-
 class BuiltinEnsemble(BuiltinModel):
     """Private template for the builtin ANI ensemble models.
 
@@ -146,7 +143,7 @@ class BuiltinEnsemble(BuiltinModel):
     """
 
     def __init__(self, species_converter, aev_computer, neural_networks,
-            energy_shifter, species_to_tensor, periodic_table_index):
+                 energy_shifter, species_to_tensor, periodic_table_index):
         super(BuiltinEnsemble, self).__init__(species_converter,
                                               aev_computer,
                                               neural_networks,
@@ -173,20 +170,19 @@ class BuiltinEnsemble(BuiltinModel):
             sae_file = get_resource(sae_file_path)
             sae_file = get_resource(sae_file_path)
             ensemble_prefix = resource_filename(package_name,
-                    ensemble_prefix_path)
+                                                ensemble_prefix_path)
             ensemble_size = int(ensemble_size)
             consts = neurochem.Constants(const_file)
 
         species_converter = SpeciesConverter(consts.species)
         aev_computer = AEVComputer(**consts)
         neural_networks = neurochem.load_model_ensemble(consts.species,
-                ensemble_prefix, ensemble_size)
+                                                        ensemble_prefix, ensemble_size)
         energy_shifter, _ = neurochem.load_sae(sae_file, return_dict=True)
         species_to_tensor = consts.species_to_tensor
 
         return cls(species_converter, aev_computer, neural_networks,
-                energy_shifter, species_to_tensor, periodic_table_index)
-
+                   energy_shifter, species_to_tensor, periodic_table_index)
 
     def __getitem__(self, index):
         """Get a single 'AEVComputer -> ANIModel -> EnergyShifter' sequential model
@@ -206,9 +202,8 @@ class BuiltinEnsemble(BuiltinModel):
                 calculations
         """
         ret = BuiltinModel(self.species_converter, self.aev_computer,
-                self.neural_networks[index], self.energy_shifter,
-                self.species_to_tensor_raw, self.periodic_table_index)
-
+                           self.neural_networks[index], self.energy_shifter,
+                           self.species_to_tensor_raw, self.periodic_table_index)
         return ret
 
     def __len__(self):
@@ -218,6 +213,7 @@ class BuiltinEnsemble(BuiltinModel):
             length (:class:`int`): Number of networks in the ensemble
         """
         return len(self.neural_networks)
+
 
 def ANI1x(periodic_table_index=False):
     """The ANI-1x model as in `ani-1x_8x on GitHub`_ and `Active Learning Paper`_.
@@ -251,5 +247,4 @@ def ANI1ccx(periodic_table_index=False):
     .. _Transfer Learning Paper:
         https://doi.org/10.26434/chemrxiv.6744440.v1
     """
-
     return BuiltinEnsemble._from_neurochem_resources('ani-1ccx_8x.info', periodic_table_index)

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -210,7 +210,8 @@ class BuiltinEnsemble(BuiltinModel):
         """
         ret = BuiltinModel(self.species_converter, self.aev_computer,
                            self.neural_networks[index], self.energy_shifter,
-                           self._species_to_tensor, self.periodic_table_index)
+                           self._species_to_tensor, self.consts, self.sae_dict,
+                           self.periodic_table_index)
         return ret
 
     def __len__(self):

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -39,6 +39,7 @@ from .aev import AEVComputer
 class BuiltinModel(torch.nn.Module):
     r"""Private template for the builtin ANI models """
     def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, periodic_table_index):
+        super(BuiltinModel, self).__init__()
         if periodic_table_index:
             self.species_converter = species_converter
         else:

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -32,7 +32,7 @@ from torch import Tensor
 from typing import Tuple, Optional
 from pkg_resources import resource_filename
 from . import neurochem
-from .nn import Sequential, SpeciesConverter, SpeciesEnergies
+from .nn import SpeciesConverter, SpeciesEnergies
 from .aev import AEVComputer
 
 
@@ -202,7 +202,7 @@ class BuiltinEnsemble(BuiltinModel):
             index (:class:`int`): Index of the model
 
         Returns:
-            ret: (:class:`Sequential`): Sequential model ready for
+            ret: (:class:`torchani.models.BuiltinModel`) Model ready for
                 calculations
         """
         ret = BuiltinModel(self.species_converter, self.aev_computer,

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -49,6 +49,39 @@ class BuiltinModel(torch.nn.Module):
         self._species_to_tensor = species_to_tensor
         self.periodic_table_index = periodic_table_index
 
+    def _from_neurochem_resources(cls, info_file_path, index=0, periodic_table_index=False):
+        # Convenience function for building only one model from the ensemble
+
+        def get_resource(file_path, package_name):
+            return resource_filename(package_name, 'resources/' + file_path)
+
+        package_name = '.'.join(__name__.split('.')[:-1])
+        info_file = get_resource(info_file_path, package_name)
+
+        with open(info_file) as f:
+            # const_file: Path to the file with the builtin constants.
+            # sae_file: Path to the file with the Self Atomic Energies.
+            # ensemble_prefix: Prefix of the neurochem resource directories.
+            lines = [x.strip() for x in f.readlines()][:4]
+            const_file_path, sae_file_path, ensemble_prefix_path, ensemble_size = lines
+            const_file = get_resource(const_file_path, package_name)
+            sae_file = get_resource(sae_file_path, package_name)
+            sae_file = get_resource(sae_file_path, package_name)
+            ensemble_prefix = resource_filename(package_name,
+                                                ensemble_prefix_path)
+            ensemble_size = int(ensemble_size)
+            consts = neurochem.Constants(const_file)
+
+        species_converter = SpeciesConverter(consts.species)
+        aev_computer = AEVComputer(**consts)
+        neural_networks = neurochem.load_model_ensemble(consts.species,
+                                                        ensemble_prefix, ensemble_size)
+        energy_shifter, _ = neurochem.load_sae(sae_file, return_dict=True)
+        species_to_tensor = consts.species_to_tensor
+
+        return cls(species_converter, aev_computer, neural_networks,
+                   energy_shifter, species_to_tensor, periodic_table_index)
+
     @torch.jit.export
     def _recast_long_buffers(self):
         self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -203,7 +203,7 @@ class BuiltinEnsemble(BuiltinModel):
         """
         ret = BuiltinModel(self.species_converter, self.aev_computer,
                            self.neural_networks[index], self.energy_shifter,
-                           self.species_to_tensor_raw, self.periodic_table_index)
+                           self._species_to_tensor, self.periodic_table_index)
         return ret
 
     def __len__(self):

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -36,64 +36,20 @@ from .nn import Sequential, SpeciesConverter, SpeciesEnergies
 from .aev import AEVComputer
 
 
-class BuiltinNet(torch.nn.Module):
-    """Private template for the builtin ANI ensemble models.
 
-    All ANI ensemble models form the ANI models zoo should inherit from this class.
-    This class is a torch module that sequentially calculates
-    AEVs, then energies from a torchani.Ensemble and then uses EnergyShifter
-    to shift those energies. It is essentially a sequential
-    'AEVComputer -> Ensemble -> EnergyShifter'.
 
-    .. note::
-        This class is for internal use only, avoid using it, use ANI1x, ANI1ccx,
-        etc instead. Don't confuse this class with torchani.Ensemble, which
-        is only a container for many ANIModel instances and shouldn't be used
-        directly for calculations.
-
-    Attributes:
-        const_file (:class:`str`): Path to the file with the builtin constants.
-        sae_file (:class:`str`): Path to the file with the Self Atomic Energies.
-        ensemble_prefix (:class:`str`): Prefix of directories.
-        ensemble_size (:class:`int`): Number of models in the ensemble.
-        energy_shifter (:class:`torchani.EnergyShifter`): Energy shifter with
-            builtin Self Atomic Energies.
-        aev_computer (:class:`torchani.AEVComputer`): AEV computer with
-            builtin constants
-        neural_networks (:class:`torchani.Ensemble`): Ensemble of ANIModel networks
-        periodic_table_index (bool): Whether to use element number in periodic table
-            to index species. If set to `False`, then indices must be `0, 1, 2, ..., N - 1`
-            where `N` is the number of parametrized species.
-    """
-
-    def __init__(self, info_file, periodic_table_index=False):
-        super(BuiltinNet, self).__init__()
+class BuiltinModel(torch.nn.Module):
+    r"""Private template for the builtin ANI models """
+    def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, periodic_table_index):
+        if periodic_table_index == True:
+            self.species_converter = species_converter
+        else:
+            self.species_converter = None
+        self.aev_computer = aev_computer
+        self.neural_networks = neural_networks
+        self.energy_shifter = energy_shifter
+        self._species_to_tensor = species_to_tensor
         self.periodic_table_index = periodic_table_index
-
-        package_name = '.'.join(__name__.split('.')[:-1])
-        info_file = 'resources/' + info_file
-        self.info_file = resource_filename(package_name, info_file)
-
-        with open(self.info_file) as f:
-            lines = [x.strip() for x in f.readlines()][:4]
-            const_file_path, sae_file_path, ensemble_prefix_path, ensemble_size = lines
-            const_file_path = 'resources/' + const_file_path
-            sae_file_path = 'resources/' + sae_file_path
-            ensemble_prefix_path = 'resources/' + ensemble_prefix_path
-            ensemble_size = int(ensemble_size)
-
-        self.const_file = resource_filename(package_name, const_file_path)
-        self.sae_file = resource_filename(package_name, sae_file_path)
-        self.ensemble_prefix = resource_filename(package_name, ensemble_prefix_path)
-        self.ensemble_size = ensemble_size
-
-        self.consts = neurochem.Constants(self.const_file)
-        self.species = self.consts.species
-        self.species_converter = SpeciesConverter(self.species)
-        self.aev_computer = AEVComputer(**self.consts)
-        self.energy_shifter, self.sae_dict = neurochem.load_sae(self.sae_file, return_dict=True)
-        self.neural_networks = neurochem.load_model_ensemble(
-            self.species, self.ensemble_prefix, self.ensemble_size)
 
     def forward(self, species_coordinates: Tuple[Tensor, Tensor],
                 cell: Optional[Tensor] = None,
@@ -117,9 +73,121 @@ class BuiltinNet(torch.nn.Module):
         species_energies = self.neural_networks(species_aevs)
         return self.energy_shifter(species_energies)
 
+    def species_to_tensor(self, *args, **kwargs):
+        """Convert species from strings to tensor.
+
+        See also :method:`torchani.neurochem.Constant.species_to_tensor`
+
+        Arguments:
+            species (:class:`str`): A string of chemical symbols
+
+        Returns:
+            tensor (:class:`torch.Tensor`): A 1D tensor of integers
+        """
+        # The only difference between this and the "raw" private version
+        # _species_to_tensor is that this sends the final tensor to the model
+        # device
+        return self._species_to_tensor(*args, **kwargs) \
+            .to(self.aev_computer.ShfR.device)
+
+    def ase(self, **kwargs):
+        """Get an ASE Calculator using this ANI model
+
+        Arguments:
+            kwargs: ase.Calculator kwargs
+
+        Returns:
+            calculator (:class:`int`): A calculator to be used with ASE
+        """
+        from . import ase
+        return ase.Calculator(self.species, self, **kwargs)
+
+
+
+class BuiltinEnsemble(BuiltinModel):
+    """Private template for the builtin ANI ensemble models.
+
+    ANI ensemble models form the ANI models zoo are instances of this class.
+    This class is a torch module that sequentially calculates
+    AEVs, then energies from a torchani.Ensemble and then uses EnergyShifter
+    to shift those energies. It is essentially a sequential
+
+    'AEVComputer -> Ensemble -> EnergyShifter' 
+
+    (periodic_table_index=False), or a sequential 
+
+    'SpeciesConverter -> AEVComputer -> Ensemble -> EnergyShifter' 
+
+    (periodic_table_index=True).
+
+    .. note::
+        This class is for internal use only, avoid relying on anything from it
+        except the public methods, always use ANI1x, ANI1ccx, etc to instance
+        the models. 
+        Also, don't confuse this class with torchani.Ensemble, which is only a
+        container for many ANIModel instances and shouldn't be used directly
+        for calculations.
+
+    Attributes:
+        species_converter (:class:`torchani.nn.SpeciesConverter`): Converts periodic table index to 
+            internal indices. Only present if periodic_table_index is `True`.
+        aev_computer (:class:`torchani.AEVComputer`): AEV computer with
+            builtin constants
+        energy_shifter (:class:`torchani.EnergyShifter`): Energy shifter with
+            builtin Self Atomic Energies.
+        periodic_table_index (bool): Whether to use element number in periodic table
+            to index species. If set to `False`, then indices must be `0, 1, 2, ..., N - 1`
+            where `N` is the number of parametrized species.
+    """
+
+    def __init__(self, species_converter, aev_computer, neural_networks,
+            energy_shifter, species_to_tensor, periodic_table_index):
+        super(BuiltinEnsemble, self).__init__(species_converter,
+                                              aev_computer,
+                                              neural_networks, 
+                                              energy_shifter,
+                                              species_to_tensor,
+                                              periodic_table_index)
+
+    @classmethod
+    def _from_neurochem_resources(cls, info_file_path, periodic_table_index=False):
+
+        def get_resource(file_path):
+            return resource_filename(package_name, 'resources/' + info_file_path)
+
+        package_name = '.'.join(__name__.split('.')[:-1])
+        info_file = get_resource(info_file_path)
+
+        with open(info_file_path) as f:
+            # const_file: Path to the file with the builtin constants.
+            # sae_file: Path to the file with the Self Atomic Energies.
+            # ensemble_prefix: Prefix of the neurochem resource directories.
+            lines = [x.strip() for x in f.readlines()][:4]
+            const_file_path, sae_file_path, ensemble_prefix_path, ensemble_size = lines
+            const_file = get_resource(const_file_path)
+            sae_file = get_resource(sae_file_path)
+            sae_file = get_resource(sae_file_path)
+            ensemble_prefix = resource_filename(package_name,
+                    ensemble_prefix_path)
+            ensemble_size = int(ensemble_size)
+            consts = neurochem.Constants(const_file)
+
+        species_converter = SpeciesConverter(consts.species)
+        aev_computer = AEVComputer(**consts)
+        neural_networks = neurochem.load_model_ensemble(consts.species,
+                ensemble_prefix, ensemble_size)
+        energy_shifter, _ = neurochem.load_sae(sae_file, return_dict=True)
+        species_to_tensor = consts.species_to_tensor
+
+        return cls(species_converter, aev_computer, neural_networks,
+                energy_shifter, species_to_tensor, periodic_table_index)
+
+
     def __getitem__(self, index):
         """Get a single 'AEVComputer -> ANIModel -> EnergyShifter' sequential model
 
+        Get a single 'AEVComputer -> ANIModel -> EnergyShifter' sequential model
+        or 
         Indexing allows access to a single model inside the ensemble
         that can be used directly for calculations. The model consists
         of a sequence AEVComputer -> ANIModel -> EnergyShifter
@@ -132,28 +200,10 @@ class BuiltinNet(torch.nn.Module):
             ret: (:class:`Sequential`): Sequential model ready for
                 calculations
         """
-        if self.periodic_table_index:
-            ret = Sequential(
-                self.species_converter,
-                self.aev_computer,
-                self.neural_networks[index],
-                self.energy_shifter
-            )
-        else:
-            ret = Sequential(
-                self.aev_computer,
-                self.neural_networks[index],
-                self.energy_shifter
-            )
+        ret = BuiltinModel(self.species_converter, self.aev_computer,
+                self.neural_networks[index], self.energy_shifter,
+                self.species_to_tensor_raw, self.periodic_table_index)
 
-        def ase(**kwargs):
-            """Attach an ase calculator """
-            from . import ase
-            return ase.Calculator(self.species, ret, **kwargs)
-
-        ret.ase = ase
-        ret.species_to_tensor = self.consts.species_to_tensor
-        ret.periodic_table_index = self.periodic_table_index
         return ret
 
     def __len__(self):
@@ -164,34 +214,7 @@ class BuiltinNet(torch.nn.Module):
         """
         return len(self.neural_networks)
 
-    def ase(self, **kwargs):
-        """Get an ASE Calculator using this ANI model ensemble
-
-        Arguments:
-            kwargs: ase.Calculator kwargs
-
-        Returns:
-            calculator (:class:`int`): A calculator to be used with ASE
-        """
-        from . import ase
-        return ase.Calculator(self.species, self, **kwargs)
-
-    def species_to_tensor(self, *args, **kwargs):
-        """Convert species from strings to tensor.
-
-        See also :method:`torchani.neurochem.Constant.species_to_tensor`
-
-        Arguments:
-            species (:class:`str`): A string of chemical symbols
-
-        Returns:
-            tensor (:class:`torch.Tensor`): A 1D tensor of integers
-        """
-        return self.consts.species_to_tensor(*args, **kwargs) \
-            .to(self.aev_computer.ShfR.device)
-
-
-class ANI1x(BuiltinNet):
+def ANI1x(periodic_table_index=False):
     """The ANI-1x model as in `ani-1x_8x on GitHub`_ and `Active Learning Paper`_.
 
     The ANI-1x model is an ensemble of 8 networks that was trained using
@@ -205,12 +228,10 @@ class ANI1x(BuiltinNet):
     .. _Active Learning Paper:
         https://aip.scitation.org/doi/abs/10.1063/1.5023802
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__('ani-1x_8x.info', *args, **kwargs)
+    return BuiltinEnsemble._from_neurochem_resources('ani-1x_8x.info', periodic_table_index)
 
 
-class ANI1ccx(BuiltinNet):
+def ANI1ccx(periodic_table_index=False):
     """The ANI-1ccx model as in `ani-1ccx_8x on GitHub`_ and `Transfer Learning Paper`_.
 
     The ANI-1ccx model is an ensemble of 8 networks that was trained
@@ -226,5 +247,4 @@ class ANI1ccx(BuiltinNet):
         https://doi.org/10.26434/chemrxiv.6744440.v1
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__('ani-1ccx_8x.info', *args, **kwargs)
+    return BuiltinEnsemble._from_neurochem_resources('ani-1ccx_8x.info', periodic_table_index)

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -117,24 +117,24 @@ class BuiltinEnsemble(BuiltinModel):
     AEVs, then energies from a torchani.Ensemble and then uses EnergyShifter
     to shift those energies. It is essentially a sequential
 
-    'AEVComputer -> Ensemble -> EnergyShifter' 
+    'AEVComputer -> Ensemble -> EnergyShifter'
 
-    (periodic_table_index=False), or a sequential 
+    (periodic_table_index=False), or a sequential
 
-    'SpeciesConverter -> AEVComputer -> Ensemble -> EnergyShifter' 
+    'SpeciesConverter -> AEVComputer -> Ensemble -> EnergyShifter'
 
     (periodic_table_index=True).
 
     .. note::
         This class is for internal use only, avoid relying on anything from it
         except the public methods, always use ANI1x, ANI1ccx, etc to instance
-        the models. 
+        the models.
         Also, don't confuse this class with torchani.Ensemble, which is only a
         container for many ANIModel instances and shouldn't be used directly
         for calculations.
 
     Attributes:
-        species_converter (:class:`torchani.nn.SpeciesConverter`): Converts periodic table index to 
+        species_converter (:class:`torchani.nn.SpeciesConverter`): Converts periodic table index to
             internal indices. Only present if periodic_table_index is `True`.
         aev_computer (:class:`torchani.AEVComputer`): AEV computer with
             builtin constants
@@ -149,7 +149,7 @@ class BuiltinEnsemble(BuiltinModel):
             energy_shifter, species_to_tensor, periodic_table_index):
         super(BuiltinEnsemble, self).__init__(species_converter,
                                               aev_computer,
-                                              neural_networks, 
+                                              neural_networks,
                                               energy_shifter,
                                               species_to_tensor,
                                               periodic_table_index)
@@ -192,7 +192,7 @@ class BuiltinEnsemble(BuiltinModel):
         """Get a single 'AEVComputer -> ANIModel -> EnergyShifter' sequential model
 
         Get a single 'AEVComputer -> ANIModel -> EnergyShifter' sequential model
-        or 
+        or
         Indexing allows access to a single model inside the ensemble
         that can be used directly for calculations. The model consists
         of a sequence AEVComputer -> ANIModel -> EnergyShifter

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -40,10 +40,7 @@ class BuiltinModel(torch.nn.Module):
     r"""Private template for the builtin ANI models """
     def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, consts, sae_dict, periodic_table_index):
         super(BuiltinModel, self).__init__()
-        if periodic_table_index:
-            self.species_converter = species_converter
-        else:
-            self.species_converter = None
+        self.species_converter = species_converter
         self.aev_computer = aev_computer
         self.neural_networks = neural_networks
         self.energy_shifter = energy_shifter

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -158,12 +158,12 @@ class BuiltinEnsemble(BuiltinModel):
     def _from_neurochem_resources(cls, info_file_path, periodic_table_index=False):
 
         def get_resource(file_path):
-            return resource_filename(package_name, 'resources/' + info_file_path)
+            return resource_filename(package_name, 'resources/' + file_path)
 
         package_name = '.'.join(__name__.split('.')[:-1])
         info_file = get_resource(info_file_path)
 
-        with open(info_file_path) as f:
+        with open(info_file) as f:
             # const_file: Path to the file with the builtin constants.
             # sae_file: Path to the file with the Self Atomic Energies.
             # ensemble_prefix: Prefix of the neurochem resource directories.

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -38,6 +38,7 @@ from .aev import AEVComputer
 
 class BuiltinModel(torch.nn.Module):
     r"""Private template for the builtin ANI models """
+
     def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, consts, sae_dict, periodic_table_index):
         super(BuiltinModel, self).__init__()
         self.species_converter = species_converter
@@ -51,11 +52,6 @@ class BuiltinModel(torch.nn.Module):
         # a bit useless maybe
         self.consts = consts
         self.sae_dict = sae_dict
-
-    @torch.jit.export
-    def _recast_long_buffers(self):
-        self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)
-        self.aev_computer.triu_index = self.aev_computer.triu_index.to(dtype=torch.long)
 
     def forward(self, species_coordinates: Tuple[Tensor, Tensor],
                 cell: Optional[Tensor] = None,
@@ -79,6 +75,12 @@ class BuiltinModel(torch.nn.Module):
         species_energies = self.neural_networks(species_aevs)
         return self.energy_shifter(species_energies)
 
+    @torch.jit.export
+    def _recast_long_buffers(self):
+        self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)
+        self.aev_computer.triu_index = self.aev_computer.triu_index.to(dtype=torch.long)
+
+    @torch.jit.export
     def species_to_tensor(self, *args, **kwargs):
         """Convert species from strings to tensor.
 

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -41,7 +41,7 @@ from .aev import AEVComputer
 class BuiltinModel(torch.nn.Module):
     r"""Private template for the builtin ANI models """
     def __init__(self, species_converter, aev_computer, neural_networks, energy_shifter, species_to_tensor, periodic_table_index):
-        if periodic_table_index == True:
+        if periodic_table_index:
             self.species_converter = species_converter
         else:
             self.species_converter = None

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -155,9 +155,9 @@ class BuiltinEnsemble(BuiltinModel):
     def _from_neurochem_resources(cls, info_file_path, periodic_table_index=False):
 
         def get_resource(file_path):
+            package_name = '.'.join(__name__.split('.')[:-1])
             return resource_filename(package_name, 'resources/' + file_path)
 
-        package_name = '.'.join(__name__.split('.')[:-1])
         info_file = get_resource(info_file_path)
 
         with open(info_file) as f:
@@ -169,8 +169,7 @@ class BuiltinEnsemble(BuiltinModel):
             const_file = get_resource(const_file_path)
             sae_file = get_resource(sae_file_path)
             sae_file = get_resource(sae_file_path)
-            ensemble_prefix = resource_filename(package_name,
-                                                ensemble_prefix_path)
+            ensemble_prefix = get_resource(ensemble_prefix_path)
             ensemble_size = int(ensemble_size)
             consts = neurochem.Constants(const_file)
 

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -80,7 +80,6 @@ class BuiltinModel(torch.nn.Module):
         self.species_converter.conv_tensor = self.species_converter.conv_tensor.to(dtype=torch.long)
         self.aev_computer.triu_index = self.aev_computer.triu_index.to(dtype=torch.long)
 
-    @torch.jit.export
     def species_to_tensor(self, *args, **kwargs):
         """Convert species from strings to tensor.
 

--- a/torchani/models.py
+++ b/torchani/models.py
@@ -174,7 +174,6 @@ class BuiltinEnsemble(BuiltinModel):
             const_file_path, sae_file_path, ensemble_prefix_path, ensemble_size = lines
             const_file = get_resource(const_file_path)
             sae_file = get_resource(sae_file_path)
-            sae_file = get_resource(sae_file_path)
             ensemble_prefix = get_resource(ensemble_prefix_path)
             ensemble_size = int(ensemble_size)
             consts = neurochem.Constants(const_file)


### PR DESCRIPTION
I don't like the current implementation of BuiltinNet, also I'm pretty sure noone likes the name. 

It is not really possible to add @torch.jit.export functions to the individual models inside a BuiltinNet, which is inconvenient for me, so I refactored it this way. I got rid of most of the internal attributes since they were not really useful. 

I wanted to know your opinion.