### PR TITLE
Fix subtract energies 

### DIFF
--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -95,7 +95,7 @@ except NameError:
 dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 batch_size = 2560
 
-training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter, species_order).species_to_indices(species_order).shuffle().split(0.8, None)
+training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 print('Self atomic energies: ', energy_shifter.self_energies)

--- a/examples/nnp_training.py
+++ b/examples/nnp_training.py
@@ -95,7 +95,7 @@ except NameError:
 dspath = os.path.join(path, '../dataset/ani1-up_to_gdb4/ani_gdb_s01.h5')
 batch_size = 2560
 
-training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
+training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter, species_order).species_to_indices(species_order).shuffle().split(0.8, None)
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()
 print('Self atomic energies: ', energy_shifter.self_energies)

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -52,7 +52,7 @@ batch_size = 2560
 training, validation = torchani.data.load(
     dspath,
     additional_properties=('forces',)
-).subtract_self_energies(energy_shifter, species_order).species_to_indices(species_order).shuffle().split(0.8, None)
+).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
 
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()

--- a/examples/nnp_training_force.py
+++ b/examples/nnp_training_force.py
@@ -52,7 +52,7 @@ batch_size = 2560
 training, validation = torchani.data.load(
     dspath,
     additional_properties=('forces',)
-).subtract_self_energies(energy_shifter).species_to_indices(species_order).shuffle().split(0.8, None)
+).subtract_self_energies(energy_shifter, species_order).species_to_indices(species_order).shuffle().split(0.8, None)
 
 training = training.collate(batch_size).cache()
 validation = validation.collate(batch_size).cache()

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -104,8 +104,8 @@ class Transformations:
     """Convert one reenterable iterable to another reenterable iterable"""
 
     @staticmethod
-    def species_to_indices(reenterable_iterable, species_order=('H', 'C', 'N', 'O', 'F', 'S', 'Cl')):
-        if species_order == 'periodic_table':
+    def species_to_indices(reenterable_iterable, species_order=None:
+        if species_order is None:
             species_order = utils.PERIODIC_TABLE
         idx = {k: i for i, k in enumerate(species_order)}
 

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -39,7 +39,7 @@ Example:
 
 .. code-block:: python
 
-    energy_shifter = torchani.utils.energyshifter(None)
+    energy_shifter = torchani.utils.EnergyShifter(None)
     training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(int(0.8 * size), None)
     training = training.collate(batch_size).cache()
     validation = validation.collate(batch_size).cache()

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -35,11 +35,11 @@ you can also use `split` to split the iterable to pieces. use `split` as:
 
 where the none in the end indicate that we want to use all of the the rest
 
-example:
+Example:
 
 .. code-block:: python
 
-    energy_shifter = torchani.utils.energyshifter(none)
+    energy_shifter = torchani.utils.energyshifter(None)
     training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(int(0.8 * size), None)
     training = training.collate(batch_size).cache()
     validation = validation.collate(batch_size).cache()

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -119,7 +119,7 @@ class Transformations:
             return IterableAdapter(reenterable_iterable_factory)
 
     @staticmethod
-    def subtract_self_energies(reenterable_iterable, self_energies=None):
+    def subtract_self_energies(reenterable_iterable, self_energies=None, species_order=None):
         intercept = 0.0
         shape_inference = False
         if isinstance(self_energies, utils.EnergyShifter):
@@ -142,8 +142,11 @@ class Transformations:
                         counts[s].append(0)
                 Y.append(d['energies'])
 
-            # sort based on the order in periodic table
-            species = sorted(list(counts.keys()), key=lambda x: utils.PERIODIC_TABLE.index(x))
+            # sort based on the order in periodic table by default
+            if species_order is None:
+                species_order = utils.PERIODIC_TABLE
+
+            species = sorted(list(counts.keys()), key=lambda x: species_order.index(x))
 
             X = [counts[s] for s in species]
             if shifter.fit_intercept:

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -110,8 +110,8 @@ class Transformations:
     """Convert one reenterable iterable to another reenterable iterable"""
 
     @staticmethod
-    def species_to_indices(reenterable_iterable, species_order=None):
-        if species_order == 'periodic_table' or species_order is None:
+    def species_to_indices(reenterable_iterable, species_order=('H', 'C', 'N', 'O', 'F', 'S', 'Cl')):
+        if species_order == 'periodic_table':
             species_order = utils.PERIODIC_TABLE
         idx = {k: i for i, k in enumerate(species_order)}
 

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -104,8 +104,8 @@ class Transformations:
     """Convert one reenterable iterable to another reenterable iterable"""
 
     @staticmethod
-    def species_to_indices(reenterable_iterable, species_order=None:
-        if species_order is None:
+    def species_to_indices(reenterable_iterable, species_order=('H', 'C', 'N', 'O', 'F', 'S', 'Cl')):
+        if species_order == 'periodic_table':
             species_order = utils.PERIODIC_TABLE
         idx = {k: i for i, k in enumerate(species_order)}
 

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -31,9 +31,9 @@ you can also use `split` to split the iterable to pieces. use `split` as:
 
 .. code-block:: python
 
-    it.split(ratio1, ratio2, none)
+    it.split(ratio1, ratio2, None)
 
-where the none in the end indicate that we want to use all of the the rest
+where the None in the end indicate that we want to use all of the the rest
 
 Example:
 

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -104,8 +104,8 @@ class Transformations:
     """Convert one reenterable iterable to another reenterable iterable"""
 
     @staticmethod
-    def species_to_indices(reenterable_iterable, species_order=('H', 'C', 'N', 'O', 'F', 'S', 'Cl')):
-        if species_order == 'periodic_table':
+    def species_to_indices(reenterable_iterable, species_order=None):
+        if species_order == 'periodic_table' or species_order is None:
             species_order = utils.PERIODIC_TABLE
         idx = {k: i for i, k in enumerate(species_order)}
 

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -21,19 +21,25 @@ Available transformations are listed below:
 - `pin_memory` copy the tensor to pinned memory so that later transfer
     to cuda could be faster.
 
-You can also use `split` to split the iterable to pieces. Use `split` as:
+By default `species_to_indices` and `subtract_self_energies` order atoms by
+atomic number. A special ordering can be used if requested, by calling
+`species_to_indices(species_order)` or `subtract_self_energies(energy_shifter,
+species_order)` however, this is definitely NOT recommended, it is best to
+always order according to atomic number.
+
+you can also use `split` to split the iterable to pieces. use `split` as:
 
 .. code-block:: python
 
-    it.split(ratio1, ratio2, None)
+    it.split(ratio1, ratio2, none)
 
-where the None in the end indicate that we want to use all of the the rest
+where the none in the end indicate that we want to use all of the the rest
 
-Example:
+example:
 
 .. code-block:: python
 
-    energy_shifter = torchani.utils.EnergyShifter(None)
+    energy_shifter = torchani.utils.energyshifter(none)
     training, validation = torchani.data.load(dspath).subtract_self_energies(energy_shifter).species_to_indices().shuffle().split(int(0.8 * size), None)
     training = training.collate(batch_size).cache()
     validation = validation.collate(batch_size).cache()


### PR DESCRIPTION
species_to_indices allows arbitrary order but subtract_self_energies does not.

I changed the code to make both functions "periodic_table_index" by default, but to allow arbitrary order if specifically asked to maintain compatibility with the rest of the code. Also, I changed the examples to reflect this