### PR TITLE
Update requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup_attrs = {
     'install_requires': [
         'torch',
         'lark-parser',
+        'requests'
     ],
 }
 


### PR DESCRIPTION
Currently "pip install torchani" fails if you dont have the "requests" module, on import.

to reproduce:
```
conda create --name=new_env python=3.7 -y
conda activate new_env
pip install torchani
python -c "import torchani"

```