### PR TITLE
Cleanup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ dist
 Untitled.ipynb
 /nnp_training.py
 /test*.py
+.coverage
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ benchmark_xyz
 *.pyc
 *checkpoint*
 *.pt
-/runs
+/tests/runs
 /quicktest.py
 /*.ipt
 /*.params

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,7 +7,6 @@ path = os.path.dirname(os.path.realpath(__file__))
 dataset_path = os.path.join(path, '../dataset/ani-1x/sample.h5')
 batch_size = 256
 ani1x = torchani.models.ANI1x()
-consts = ani1x.consts
 sae_dict = ani1x.sae_dict
 aev_computer = ani1x.aev_computer
 

--- a/tests/test_neurochem.py
+++ b/tests/test_neurochem.py
@@ -13,7 +13,7 @@ class TestNeuroChem(unittest.TestCase):
 
     def testNeuroChemTrainer(self):
         d = torch.device('cpu')
-        trainer = torchani.neurochem.Trainer(iptpath, d, True, 'runs')
+        trainer = torchani.neurochem.Trainer(iptpath, d, True, os.path.join(path, 'runs'))
 
         # test if loader construct correct model
         self.assertEqual(trainer.aev_computer.aev_length, 384)

--- a/tests/test_vibrational.py
+++ b/tests/test_vibrational.py
@@ -34,6 +34,7 @@ class TestVibrational(unittest.TestCase):
         modes = []
         for j in range(6, 6 + len(freq)):
             modes.append(vib.get_mode(j))
+        vib.clean()
         modes = torch.tensor(modes)
         # compute vibrational by torchani
         species = model.species_to_tensor(molecule.get_chemical_symbols()).unsqueeze(0)


### PR DESCRIPTION
Added some very small cleanup to tests. Now test_neurochem always creates tensorboard outputs in /tests/ and all pickle files are cleaned up after vibrational_analysis is performed. Also added code coverage to gitignore 