### PR TITLE
Add new test with hardcoded saes (address issue #485)

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -111,6 +111,7 @@ class TestData(unittest.TestCase):
     def testSAE(self):
         tolerance = 1e-5
         shifter = torchani.EnergyShifter(None)
+        torchani.data.load(dataset_path).subtract_self_energies(shifter)
         true_self_energies = torch.tensor([-19.354171758844188,
                                            -19.354171758844046,
                                            -54.712238523648587,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -111,11 +111,11 @@ class TestData(unittest.TestCase):
     def testSAE(self):
         tolerance = 1e-5
         shifter = torchani.EnergyShifter(None)
-        ds = torchani.data.load(dataset_path).subtract_self_energies(shifter)
         true_self_energies = torch.tensor([-19.354171758844188,
-            -19.354171758844046, -54.712238523648587, -75.162829556770987],
-            dtype=torch.float64)
-        diff =  torch.abs(true_self_energies - shifter.self_energies)
+                                           -19.354171758844046,
+                                           -54.712238523648587,
+                                           -75.162829556770987], dtype=torch.float64)
+        diff = torch.abs(true_self_energies - shifter.self_energies)
         for e in diff:
             self.assertLess(e, tolerance)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -108,6 +108,17 @@ class TestData(unittest.TestCase):
         ds = ds.collate(batch_size)
         len(ds)
 
+    def testSAE(self):
+        tolerance = 1e-5
+        shifter = torchani.EnergyShifter(None)
+        ds = torchani.data.load(dataset_path).subtract_self_energies(shifter)
+        true_self_energies = torch.tensor([-19.354171758844188,
+            -19.354171758844046, -54.712238523648587, -75.162829556770987],
+            dtype=torch.float64)
+        diff =  torch.abs(true_self_energies - shifter.self_energies)
+        for e in diff:
+            self.assertLess(e, tolerance)
+
     def testDataloader(self):
         shifter = torchani.EnergyShifter(None)
         dataset = list(torchani.data.load(dataset_path).subtract_self_energies(shifter).species_to_indices().shuffle())


### PR DESCRIPTION
This adds the test @farhadrgh asked me to do in #485 . I currently hardcoded the numbers to the current output of the EnergyShifter for `ani-1x/sample.h5` which is not very elegant but should be correct, recommendations appreciated.