### PR TITLE
Fix gradcheck test

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,7 +20,8 @@ jobs:
           test_aev.py, test_aev_benzene_md.py, test_aev_nist.py, test_aev_tripeptide_md.py,
           test_utils.py, test_ase.py, test_energies.py, test_periodic_table_indexing.py,
           test_neurochem.py, test_vibrational.py, test_ensemble.py, test_padding.py,
-          test_data.py, test_forces.py, test_structure_optim.py, test_jit_builtin_models.py]
+          test_data.py, test_forces.py, test_structure_optim.py, test_jit_builtin_models.py, 
+          test_grad.py]
 
     steps:
     - uses: actions/checkout@v1

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -25,7 +25,6 @@ class TestIsolated(unittest.TestCase):
         else:
             self.device = 'cpu'
         ani1x = torchani.models.ANI1x().to(self.device)
-        self.model = ani1x
         self.aev_computer = ani1x.aev_computer
         self.species_to_tensor = ani1x.species_to_tensor
         self.rcr = ani1x.aev_computer.Rcr

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -3,7 +3,6 @@ import torchani
 import unittest
 import os
 import pickle
-import copy
 import itertools
 import ase
 import ase.io
@@ -26,6 +25,7 @@ class TestIsolated(unittest.TestCase):
         else:
             self.device = 'cpu'
         ani1x = torchani.models.ANI1x().to(self.device)
+        self.model = ani1x
         self.aev_computer = ani1x.aev_computer
         self.species_to_tensor = ani1x.species_to_tensor
         self.rcr = ani1x.aev_computer.Rcr
@@ -131,41 +131,6 @@ class TestAEV(_TestAEVBase):
             aev_ = aev[start:(start + conformations), 0:atoms]
             start += conformations
             self.assertAEVEqual(expected_radial, expected_angular, aev_)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "Too slow on CPU")
-    def testGradient(self):
-        """Test validity of autodiff by comparing analytical and numerical
-        gradients.
-        """
-        datafile = os.path.join(path, 'test_data/NIST/all')
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        # Create local copy of aev_computer to avoid interference with other
-        # tests.
-        aev_computer = copy.deepcopy(self.aev_computer).to(device).to(torch.float64)
-        with open(datafile, 'rb') as f:
-            data = pickle.load(f)
-            for coordinates, species, _, _, _, _ in data:
-                coordinates = torch.from_numpy(coordinates).to(device).to(torch.float64)
-                coordinates.requires_grad_(True)
-                species = torch.from_numpy(species).to(device)
-
-                # PyTorch gradcheck expects to test a funtion with inputs and
-                # outputs of type torch.Tensor. The numerical estimation of
-                # the deriviate involves making small modifications to the
-                # input and observing how it affects the output. The species
-                # tensor needs to be removed from the input so that gradcheck
-                # does not attempt to estimate the gradient with respect to
-                # species and fail.
-                # Create simple function wrapper to handle this.
-                def aev_forward_wrapper(coords):
-                    # Return only the aev portion of the output.
-                    return aev_computer((species, coords))[1]
-                # Sanity Check: Forward wrapper returns aev without error.
-                aev_forward_wrapper(coordinates)
-                torch.autograd.gradcheck(
-                    aev_forward_wrapper,
-                    coordinates
-                )
 
 
 class TestAEVJIT(TestAEV):

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -7,45 +7,52 @@ import pickle
 path = os.path.dirname(os.path.realpath(__file__))
 
 
-class _TestGrad(unittest.TestCase):
+class TestGrad(unittest.TestCase):
+    # torch.autograd.gradcheck and torch.autograd.gradgradcheck verify that
+    # the numerical and analytical gradient and hessian of a function
+    # matches to within a given tolerance.
+    #
+    # The forward call of the function is wrapped with a lambda so that
+    # gradcheck gets a function with only one tensor input and tensor output.
+
+    # nondet_tol is necessarily greater than zero since some operations are
+    # nondeterministic which makes two equal inputs have different outputs
 
     def setUp(self):
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = torch.device(
+            'cuda' if torch.cuda.is_available() else 'cpu')
 
-        self.model = torchani.models.ANI1x(model_index=0).to(device=self.device, dtype=torch.double)
+        self.model = torchani.models.ANI1x(model_index=0).to(
+            device=self.device, dtype=torch.double)
         datafile = os.path.join(path, 'test_data/NIST/all')
 
         # Some small molecules are selected to make the tests faster
         self.data = pickle.load(open(datafile, 'rb'))[1243:1250]
 
-    def testGrad(self):
+    def testGradCheck(self):
         for coordinates, species, _, _, _, _ in self.data:
 
-            coordinates = torch.from_numpy(coordinates).to(device=self.device, dtype=torch.float64)
+            coordinates = torch.from_numpy(coordinates).to(device=self.device,
+                                                           dtype=torch.float64)
             coordinates.requires_grad_(True)
 
             species = torch.from_numpy(species).to(self.device)
 
-            # forward call is wrapped with a lambda so that gradcheck gets a
-            # function with only one tensor input and tensor output.
+            torch.autograd.gradcheck(lambda x: self.model(
+                (species, x)).energies,
+                                     coordinates,
+                                     nondet_tol=1e-13)
 
-            # nondet_tol is necessary since some operations are
-            # nondeterministic which makes two equal inputs have different
-            # outputs
-            torch.autograd.gradcheck(lambda x: self.model((species, x)).energies, coordinates, nondet_tol=1e-13)
-
-    def testGradGrad(self):
+    def testGradGradCheck(self):
         for coordinates, species, _, _, _, _ in self.data:
 
-            coordinates = torch.from_numpy(coordinates).to(device=self.device, dtype=torch.float64)
+            coordinates = torch.from_numpy(coordinates).to(device=self.device,
+                                                           dtype=torch.float64)
             coordinates.requires_grad_(True)
 
             species = torch.from_numpy(species).to(self.device)
 
-            # forward call is wrapped with a lambda so that gradcheck gets a
-            # function with only one tensor input and tensor output.
-
-            # nondet_tol is necessary since some operations are
-            # nondeterministic which makes two equal inputs have different
-            # outputs
-            torch.autograd.gradgradcheck(lambda x: self.model((species, x)).energies, coordinates, nondet_tol=1e-13)
+            torch.autograd.gradgradcheck(lambda x: self.model(
+                (species, x)).energies,
+                                         coordinates,
+                                         nondet_tol=1e-13)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -22,7 +22,7 @@ class TestGrad(unittest.TestCase):
         self.device = torch.device(
             'cuda' if torch.cuda.is_available() else 'cpu')
 
-        self.model = torchani.models.ANI1x(model_index=0).to(device=self.device, 
+        self.model = torchani.models.ANI1x(model_index=0).to(device=self.device,
                                                              dtype=torch.double)
         datafile = os.path.join(path, 'test_data/NIST/all')
 

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -1,0 +1,51 @@
+import torch
+import torchani
+import unittest
+import os
+import pickle
+
+path = os.path.dirname(os.path.realpath(__file__))
+
+
+class _TestGrad(unittest.TestCase):
+
+    def setUp(self):
+        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+        self.model = torchani.models.ANI1x(model_index=0).to(device=self.device, dtype=torch.double)
+        datafile = os.path.join(path, 'test_data/NIST/all')
+
+        # Some small molecules are selected to make the tests faster
+        self.data = pickle.load(open(datafile, 'rb'))[1243:1250]
+
+    def testGrad(self):
+        for coordinates, species, _, _, _, _ in self.data:
+
+            coordinates = torch.from_numpy(coordinates).to(device=self.device, dtype=torch.float64)
+            coordinates.requires_grad_(True)
+
+            species = torch.from_numpy(species).to(self.device)
+
+            # forward call is wrapped with a lambda so that gradcheck gets a
+            # function with only one tensor input and tensor output.
+
+            # nondet_tol is necessary since some operations are
+            # nondeterministic which makes two equal inputs have different
+            # outputs
+            torch.autograd.gradcheck(lambda x: self.model((species, x)).energies, coordinates, nondet_tol=1e-13)
+
+    def testGradGrad(self):
+        for coordinates, species, _, _, _, _ in self.data:
+
+            coordinates = torch.from_numpy(coordinates).to(device=self.device, dtype=torch.float64)
+            coordinates.requires_grad_(True)
+
+            species = torch.from_numpy(species).to(self.device)
+
+            # forward call is wrapped with a lambda so that gradcheck gets a
+            # function with only one tensor input and tensor output.
+
+            # nondet_tol is necessary since some operations are
+            # nondeterministic which makes two equal inputs have different
+            # outputs
+            torch.autograd.gradgradcheck(lambda x: self.model((species, x)).energies, coordinates, nondet_tol=1e-13)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -22,8 +22,8 @@ class TestGrad(unittest.TestCase):
         self.device = torch.device(
             'cuda' if torch.cuda.is_available() else 'cpu')
 
-        self.model = torchani.models.ANI1x(model_index=0).to(
-            device=self.device, dtype=torch.double)
+        self.model = torchani.models.ANI1x(model_index=0).to(device=self.device, 
+                                                             dtype=torch.double)
         datafile = os.path.join(path, 'test_data/NIST/all')
 
         # Some small molecules are selected to make the tests faster
@@ -38,8 +38,7 @@ class TestGrad(unittest.TestCase):
 
             species = torch.from_numpy(species).to(self.device)
 
-            torch.autograd.gradcheck(lambda x: self.model(
-                (species, x)).energies,
+            torch.autograd.gradcheck(lambda x: self.model((species, x)).energies,
                                      coordinates,
                                      nondet_tol=1e-13)
 
@@ -52,7 +51,6 @@ class TestGrad(unittest.TestCase):
 
             species = torch.from_numpy(species).to(self.device)
 
-            torch.autograd.gradgradcheck(lambda x: self.model(
-                (species, x)).energies,
+            torch.autograd.gradgradcheck(lambda x: self.model((species, x)).energies,
                                          coordinates,
                                          nondet_tol=1e-13)


### PR DESCRIPTION
This PR adds two new tests, testGradCheck and testGradGradCheck, which are done in a way that 
are actually feasible in CPU and CUDA (tests take in total ~4 s in CPU). Currently these tests pass.

This PR deletes testGradient which was essentially never run since it was skipped by github and also always failed.
The issue was nondet_tol which was set to zero but shouldn't be, since many pytorch operations we perform use atomic_add and
similar nondeterministic ops internally, which means two inputs have very slightly different outputs. Also this test was incredibly slow.
