### PR TITLE
Specify dtype for species

### DIFF
--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -146,7 +146,7 @@ class Transformations:
 
         def reenterable_iterable_factory():
             for d in reenterable_iterable:
-                d['species'] = numpy.array([idx[s] for s in d['species']])
+                d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i4')
                 yield d
         try:
             return IterableAdapterWithLength(reenterable_iterable_factory, len(reenterable_iterable))

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -146,7 +146,7 @@ class Transformations:
 
         def reenterable_iterable_factory():
             for d in reenterable_iterable:
-                d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i4')
+                d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i8')
                 yield d
         try:
             return IterableAdapterWithLength(reenterable_iterable_factory, len(reenterable_iterable))


### PR DESCRIPTION
For some reason, sometimes species are constructed as int tensors instead of long tensors, this is wrong and should be fixed