### PR TITLE
Use torch.linalg.norm instead of torch.norm

### DIFF
--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -338,7 +338,7 @@ def vibrational_analysis(masses, hessian, mode_type='MDU', unit='cm^-1'):
     # Note that the normal modes are the COLUMNS of the eigenvectors matrix
     mw_normalized = eigenvectors.t()
     md_unnormalized = mw_normalized * inv_sqrt_mass
-    norm_factors = 1 / torch.norm(md_unnormalized, dim=1)  # units are sqrt(AMU)
+    norm_factors = 1 / torch.linalg.norm(md_unnormalized, dim=1)  # units are sqrt(AMU)
     md_normalized = md_unnormalized * norm_factors.unsqueeze(1)
 
     rmasses = norm_factors**2  # units are AMU


### PR DESCRIPTION
torch.norm is deprecated and may be removed in a future PyTorch release

fixes #514 