### PR TITLE
Simplify pair computation on AEV

### DIFF
--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -139,6 +139,7 @@ def neighbor_pairs(padding_mask: Tensor, coordinates: Tensor, cell: Tensor,
         shifts (:class:`torch.Tensor`): tensor of shape (?, 3) storing shifts
     """
     coordinates = coordinates.detach()
+    coordinates.masked_fill_(padding_mask.unsqueeze(-1), math.nan)
     cell = cell.detach()
     num_atoms = padding_mask.shape[1]
     num_mols = padding_mask.shape[0]
@@ -166,8 +167,6 @@ def neighbor_pairs(padding_mask: Tensor, coordinates: Tensor, cell: Tensor,
     # step 5, compute distances, and find all pairs within cutoff
     selected_coordinates = coordinates.index_select(1, p12_all.view(-1)).view(num_mols, 2, -1, 3)
     distances = (selected_coordinates[:, 0, ...] - selected_coordinates[:, 1, ...] + shift_values).norm(2, -1)
-    padding_mask = padding_mask.index_select(1, p12_all.view(-1)).view(2, -1).any(0)
-    distances.masked_fill_(padding_mask, math.inf)
     in_cutoff = (distances <= cutoff).nonzero()
     molecule_index, pair_index = in_cutoff.unbind(1)
     molecule_index *= num_atoms
@@ -190,6 +189,7 @@ def neighbor_pairs_nopbc(padding_mask: Tensor, coordinates: Tensor, cutoff: floa
         cutoff (float): the cutoff inside which atoms are considered pairs
     """
     coordinates = coordinates.detach()
+    coordinates.masked_fill_(padding_mask.unsqueeze(-1), math.nan)
     current_device = coordinates.device
     num_atoms = padding_mask.shape[1]
     num_mols = padding_mask.shape[0]
@@ -198,8 +198,6 @@ def neighbor_pairs_nopbc(padding_mask: Tensor, coordinates: Tensor, cutoff: floa
 
     pair_coordinates = coordinates.index_select(1, p12_all_flattened).view(num_mols, 2, -1, 3)
     distances = (pair_coordinates[:, 0, ...] - pair_coordinates[:, 1, ...]).norm(2, -1)
-    padding_mask = padding_mask.index_select(1, p12_all_flattened).view(num_mols, 2, -1).any(dim=1)
-    distances.masked_fill_(padding_mask, math.inf)
     in_cutoff = (distances <= cutoff).nonzero()
     molecule_index, pair_index = in_cutoff.unbind(1)
     molecule_index *= num_atoms

--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -138,8 +138,7 @@ def neighbor_pairs(padding_mask: Tensor, coordinates: Tensor, cell: Tensor,
         cutoff (float): the cutoff inside which atoms are considered pairs
         shifts (:class:`torch.Tensor`): tensor of shape (?, 3) storing shifts
     """
-    coordinates = coordinates.detach()
-    coordinates.masked_fill_(padding_mask.unsqueeze(-1), math.nan)
+    coordinates = coordinates.detach().masked_fill(padding_mask.unsqueeze(-1), math.nan)
     cell = cell.detach()
     num_atoms = padding_mask.shape[1]
     num_mols = padding_mask.shape[0]
@@ -188,8 +187,7 @@ def neighbor_pairs_nopbc(padding_mask: Tensor, coordinates: Tensor, cutoff: floa
             (molecules, atoms, 3) for atom coordinates.
         cutoff (float): the cutoff inside which atoms are considered pairs
     """
-    coordinates = coordinates.detach()
-    coordinates.masked_fill_(padding_mask.unsqueeze(-1), math.nan)
+    coordinates = coordinates.detach().masked_fill(padding_mask.unsqueeze(-1), math.nan)
     current_device = coordinates.device
     num_atoms = padding_mask.shape[1]
     num_mols = padding_mask.shape[0]


### PR DESCRIPTION
Because nan < number is always false.

Benchmark

Before
```
torchani.aev.cutoff_cosine - 0.1s
torchani.aev.radial_terms - 0.2s
torchani.aev.angular_terms - 0.6s
torchani.aev.compute_shifts - 0.0s
torchani.aev.neighbor_pairs - 0.0s
torchani.aev.neighbor_pairs_nopbc - 1.9s
torchani.aev.triu_index - 0.0s
torchani.aev.cumsum_from_zero - 0.1s
torchani.aev.triple_by_molecule - 2.5s
torchani.aev.compute_aev - 6.6s
Total AEV - 6.6s
NN - 13.0s
Epoch time - 29.6s
```

vs

After
```
torchani.aev.cutoff_cosine - 0.1s
torchani.aev.radial_terms - 0.2s
torchani.aev.angular_terms - 0.6s
torchani.aev.compute_shifts - 0.0s
torchani.aev.neighbor_pairs - 0.0s
torchani.aev.neighbor_pairs_nopbc - 1.7s
torchani.aev.triu_index - 0.0s
torchani.aev.cumsum_from_zero - 0.1s
torchani.aev.triple_by_molecule - 2.4s
torchani.aev.compute_aev - 6.3s
Total AEV - 6.3s
NN - 12.9s
Epoch time - 29.4s
```