### PR TITLE
Use handwritten cosine similarity

### DIFF
--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -66,10 +66,9 @@ def angular_terms(Rca: float, ShfZ: Tensor, EtaA: Tensor, Zeta: Tensor,
     vectors12 = vectors12.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
     distances12 = vectors12.norm(2, dim=-5)
 
-    # 0.95 is multiplied to the cos values to prevent acos from
-    # returning NaN.
-    cos_angles = 0.95 * torch.nn.functional.cosine_similarity(vectors12[0], vectors12[1], dim=-5)
-    angles = torch.acos(cos_angles)
+    cos_angles = vectors12.prod(0).sum(1) / distances12.prod(0)
+    # 0.95 is multiplied to the cos values to prevent acos from returning NaN.
+    angles = torch.acos(0.95 * cos_angles)
 
     fcj12 = cutoff_cosine(distances12, Rca)
     factor1 = ((1 + torch.cos(angles - ShfZ)) / 2) ** Zeta


### PR DESCRIPTION
because it is faster.

Before:
```
torchani.aev.cutoff_cosine - 2.0s
torchani.aev.radial_terms - 0.7s
torchani.aev.angular_terms - 6.1s
torchani.aev.compute_shifts - 0.0s
torchani.aev.neighbor_pairs - 0.0s
torchani.aev.neighbor_pairs_nopbc - 1.9s
torchani.aev.triu_index - 0.0s
torchani.aev.cumsum_from_zero - 0.5s
torchani.aev.triple_by_molecule - 3.4s
torchani.aev.compute_aev - 15.8s
Total AEV - 15.8s
NN - 4.1s
Epoch time - 30.3s
```

After:
```
torchani.aev.cutoff_cosine - 1.6s
torchani.aev.radial_terms - 0.7s
torchani.aev.angular_terms - 5.6s
torchani.aev.compute_shifts - 0.0s
torchani.aev.neighbor_pairs - 0.0s
torchani.aev.neighbor_pairs_nopbc - 1.8s
torchani.aev.triu_index - 0.0s
torchani.aev.cumsum_from_zero - 0.5s
torchani.aev.triple_by_molecule - 3.3s
torchani.aev.compute_aev - 15.0s
Total AEV - 15.0s
NN - 3.9s
Epoch time - 29.4s
```