### PR TITLE
Fix handwritten cosine similarity and add test for NaNs in AEVComputer

### DIFF
--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -118,6 +118,13 @@ class TestAEV(_TestAEVBase):
                 _, aev = self.aev_computer((species, coordinates))
                 self.assertAEVEqual(expected_radial, expected_angular, aev)
 
+    def testNoNan(self):
+        # AEV should not output NaN even when coordinates are superimposed
+        coordinates = torch.ones(1, 3, 3, dtype=torch.float)
+        species = torch.zeros(1, 3, dtype=torch.long)
+        _, aev = self.aev_computer((species, coordinates))
+        self.assertFalse(torch.isnan(aev).any())
+
     def testPadding(self):
         species_coordinates = []
         radial_angular = []

--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -76,8 +76,7 @@ def angular_terms(Rca: float, ShfZ: Tensor, EtaA: Tensor, Zeta: Tensor,
     """
     vectors12 = vectors12.view(2, -1, 3, 1, 1, 1, 1)
     distances12 = vectors12.norm(2, dim=-5)
-
-    cos_angles = vectors12.prod(0).sum(1) / distances12.prod(0)
+    cos_angles = vectors12.prod(0).sum(1) / torch.clamp(distances12.prod(0), min=1e-10)
     # 0.95 is multiplied to the cos values to prevent acos from returning NaN.
     angles = torch.acos(0.95 * cos_angles)
 


### PR DESCRIPTION
Handwritten cosine similarity outputs NaN values for superimposed coordinates due to the singularity in v1 dot v2 / ||v1|| * ||v2|| when one of the vectors has zero distance. 

Sometimes, during an MD simulation with many many many atoms, 2 atoms are randomly pushed to the same coordinate value.
When this happens torchani outputs NaN as an energy and the simulation breaks.

With clamp:
```
torchani.aev.cutoff_cosine - 0.2s
   torchani.aev.radial_terms - 0.3s
   torchani.aev.angular_terms - 0.8s
   torchani.aev.compute_shifts - 0.0s
   torchani.aev.neighbor_pairs - 0.0s
   torchani.aev.neighbor_pairs_nopbc - 3.7s
   torchani.aev.triu_index - 0.0s
   torchani.aev.cumsum_from_zero - 0.1s
   torchani.aev.triple_by_molecule - 3.2s
   torchani.aev.compute_aev - 9.9s
Total AEV - 10.0s
Forward - 18.1s
Backward - 4.0s
Optimizer - 4.3s
Others - 1.7s
Epoch time - 38.1s
```

Without clamp:
```
  torchani.aev.cutoff_cosine - 0.2s
   torchani.aev.radial_terms - 0.3s
   torchani.aev.angular_terms - 0.7s
   torchani.aev.compute_shifts - 0.0s
   torchani.aev.neighbor_pairs - 0.0s
   torchani.aev.neighbor_pairs_nopbc - 3.6s
   torchani.aev.triu_index - 0.0s
   torchani.aev.cumsum_from_zero - 0.1s
   torchani.aev.triple_by_molecule - 3.2s
   torchani.aev.compute_aev - 9.8s
Total AEV - 9.8s
Forward - 18.0s
Backward - 4.0s
Optimizer - 4.3s
Others - 1.7s
Epoch time - 37.9s
```

Clamp should affect only angular terms so there is essentially no performance dip (~ 0.1 s maybe)

