### PR TITLE
handle OSError in parse_neurochem_resources

### DIFF
--- a/torchani/neurochem/parse_resources.py
+++ b/torchani/neurochem/parse_resources.py
@@ -43,7 +43,7 @@ def parse_neurochem_resources(info_file_path):
             resource_zip = zipfile.ZipFile(io.BytesIO(resource_res.content))
             try:
                 resource_zip.extractall(resource_path)
-            except PermissionError:
+            except (PermissionError, OSError):
                 resource_zip.extractall(local_dir)
                 resource_path = local_dir
             source = os.path.join(resource_path, extracted_name, "resources")


### PR DESCRIPTION
Hi,
We're running TorchANI in an environment where the python packages are mounted in a read-only directory. `_parse_neurochem_resources` attempts to extract resources into the package directory and this raises a OSError for us. There's already handling for writing to a local folder in the home directory when a PermissionError is raised; this pull request applies the same handling to the OSError case as well and fixes this issue for us. 
Thanks!