### PR TITLE
Fixed: symeig deprication

### DIFF
--- a/torchani/ase.py
+++ b/torchani/ase.py
@@ -50,7 +50,7 @@ class Calculator(ase.calculators.calculator.Calculator):
     def calculate(self, atoms=None, properties=['energy'],
                   system_changes=ase.calculators.calculator.all_changes):
         super().calculate(atoms, properties, system_changes)
-        cell = torch.tensor(self.atoms.get_cell(complete=True),
+        cell = torch.tensor(self.atoms.get_cell(complete=True).array,
                             dtype=self.dtype, device=self.device)
         pbc = torch.tensor(self.atoms.get_pbc(), dtype=torch.bool,
                            device=self.device)

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -322,7 +322,7 @@ def vibrational_analysis(masses, hessian, mode_type='MDU', unit='cm^-1'):
     if mass_scaled_hessian.shape[0] != 1:
         raise ValueError('The input should contain only one molecule')
     mass_scaled_hessian = mass_scaled_hessian.squeeze(0)
-    eigenvalues, eigenvectors = torch.symeig(mass_scaled_hessian, eigenvectors=True)
+    eigenvalues, eigenvectors = torch.linalg.eigh(mass_scaled_hessian)
     angular_frequencies = eigenvalues.sqrt()
     frequencies = angular_frequencies / (2 * math.pi)
     # converting from sqrt(hartree / (amu * angstrom^2)) to cm^-1 or meV


### PR DESCRIPTION
This PR fixes an issue with `torch.symeig`, which is now deprecated. Instead, it is suggested to work with `torch.linalg.eigh`