### PR TITLE
Every time I reinstall torchani i get this error message about atoms being bytes instead of strings, this easily fixes this.

### DIFF
--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -161,7 +161,7 @@ class Transformations:
 
         def reenterable_iterable_factory():
             for d in reenterable_iterable:
-                d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i8')
+                d['species'] = numpy.array([idx[s.decode()] for s in d['species']], dtype='i8')
                 yield d
         try:
             return IterableAdapterWithLength(reenterable_iterable_factory, len(reenterable_iterable))

--- a/torchani/data/__init__.py
+++ b/torchani/data/__init__.py
@@ -161,7 +161,10 @@ class Transformations:
 
         def reenterable_iterable_factory():
             for d in reenterable_iterable:
-                d['species'] = numpy.array([idx[s.decode()] for s in d['species']], dtype='i8')
+                try:
+                    d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i8')
+                except:
+                    d['species'] = numpy.array([idx[s.decode()] for s in d['species']], dtype='i8')
                 yield d
         try:
             return IterableAdapterWithLength(reenterable_iterable_factory, len(reenterable_iterable))


### PR DESCRIPTION
Error:

  File ~\anaconda3\lib\site-packages\torchani\data\__init__.py:164 in reenterable_iterable_factory
    d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i8')

  File ~\anaconda3\lib\site-packages\torchani\data\__init__.py:164 in <listcomp>
    d['species'] = numpy.array([idx[s] for s in d['species']], dtype='i8')

KeyError: b'C'




The proposed fix will allow the program to work wether it parses the atomic labels as bytes or strings by using .decode() within a try-catch