### PR TITLE
fix pytorch version comparison

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,7 +268,7 @@ def setup_kwargs() -> tp.Dict[str, tp.Any]:
 
     # CUB needed to build the cuAEV, download it if not found bundled with Torch
     include_paths_kwargs: tp.Dict[str, tp.Any]
-    if float(".".join(torch.__version__.split(".")[:2])) >= 2.7:
+    if tuple(map(int, torch.__version__.split(".")[:2])) >= (2, 7):
         include_paths_kwargs = {"device_type": "cuda"}
     else:
         include_paths_kwargs = {"cuda": True}


### PR DESCRIPTION
the current pytorch version comparison ceases to work for pytorch >=2.10 (which, as a float, is not greater than 2.7)

I encountered this in conda-forge in https://github.com/conda-forge/torchani-feedstock/pull/56; @mgorny found the culprit. 🙏 